### PR TITLE
Use submitted test-spec as a full filename

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -161,7 +161,7 @@ Running the tests
 The ``run_testr`` command has the following options::
 
   $ run_testr --help
-  usage: run_testr [-h] [--test-spec TEST_SPEC] [--packages-dir PACKAGES_DIR]
+  usage: run_testr [-h] [--test-spec TEST_SPEC_FILE] [--packages-dir PACKAGES_DIR]
                    [--outputs-dir OUTPUTS_DIR] [--outputs-subdir OUTPUTS_SUBDIR]
                    [--regress-dir REGRESS_DIR] [--include INCLUDES]
                    [--exclude EXCLUDES] [--collect-only]
@@ -169,8 +169,8 @@ The ``run_testr`` command has the following options::
 
   optional arguments:
     -h, --help            show this help message and exit
-    --test-spec TEST_SPEC
-                          Test include/exclude specification (default=None)
+    --test-spec TEST_SPEC_FILE
+                          Test include/exclude specification file(default=None)
     --packages-dir PACKAGES_DIR
                           Directory containing package tests
     --outputs-dir OUTPUTS_DIR
@@ -295,7 +295,7 @@ manage these lists of tests directly.
 The ``--test-spec`` command line option provides a way to do this.  If you provide
 an option like ``--test-spec=HEAD`` then the following happens:
 
-- A file in the current directory named ``test_spec_HEAD`` is opened and read:
+- A file in the current directory named ``HEAD`` is opened and read:
 
   - It must contain a list of include / exclude specifications like those for
     the ``-include`` and ``-exclude`` options.

--- a/testr/packages.py
+++ b/testr/packages.py
@@ -338,7 +338,7 @@ def process_opt():
         # and reads additional test file include/excludes.
         opt.regress_dir = os.path.join(opt.regress_dir, opt.test_spec)
 
-        with open('test_spec_{}'.format(opt.test_spec), 'r') as fh:
+        with open('{}'.format(opt.test_spec), 'r') as fh:
             specs = (line.strip() for line in fh)
             specs = [spec for spec in specs if spec and not spec.startswith('#')]
 


### PR DESCRIPTION
Use submitted test-spec as a full filename

I keep trying to tab complete my test-spec file. Instead of fixing my tabbing, can we just have run_testr --test-spec take a file argument (instead of the string at the back half of the file)?