### PR TITLE
Test helpers: has_sybase(), on_head_network() and is_32_bit() + version 4.3

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,8 @@ testing of a set of packages within a production runtime environment.  The
 primary component of ``testr`` is lightweight testing script and file structure
 definition that simple but can support complex testing as needed.  The secondary
 component is a couple of helper functions that make it easier to define and run
-Python package unit tests.
+Python package unit tests.  This includes a ``test_helper`` module with some
+helper functions.
 
 .. toctree::
    :maxdepth: 2
@@ -506,4 +507,10 @@ testr.setup_helper
 ^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: testr.setup_helper
+   :members:
+
+testr.test_helper
+^^^^^^^^^^^^^^^^^
+
+.. automodule:: testr.test_helper
    :members:

--- a/testr/__init__.py
+++ b/testr/__init__.py
@@ -5,4 +5,4 @@ Testing framework for Ska runtime environment.
 
 __version__ = '3.2'
 
-from .runner import test, testr
+from .runner import test, testr  # noqa

--- a/testr/__init__.py
+++ b/testr/__init__.py
@@ -3,6 +3,6 @@
 Testing framework for Ska runtime environment.
 """
 
-__version__ = '3.2'
+__version__ = '4.3'
 
 from .runner import test, testr  # noqa

--- a/testr/runner.py
+++ b/testr/runner.py
@@ -12,7 +12,7 @@ class TestError(Exception):
 
 
 def testr(*args, **kwargs):
-    """
+    r"""
     Run py.test unit tests for the calling package.  This just calls the ``test()``
     function but includes defaults that are more appropriate for integrated package
     testing using run_testr.
@@ -37,7 +37,7 @@ def testr(*args, **kwargs):
 
 
 def test(*args, **kwargs):
-    """
+    r"""
     Run py.test unit tests for the calling package with specified
     ``args`` and ``kwargs``.
 

--- a/testr/setup_helper.py
+++ b/testr/setup_helper.py
@@ -27,5 +27,6 @@ class PyTest(TestCommand):
         errno = pytest.main(self.args)
         sys.exit(errno)
 
+
 # setup() cmdclass keyword for testing with py.test
 cmdclass = {'test': PyTest}

--- a/testr/test_helper.py
+++ b/testr/test_helper.py
@@ -3,11 +3,12 @@
 Provide helper functions that are useful for unit testing.
 """
 
+import sys
 import os
 from pathlib import Path
 import socket
 
-__all__ = ['has_sybase', 'on_head_network']
+__all__ = ['has_sybase', 'on_head_network', 'is_32_bit']
 
 
 def has_sybase():
@@ -48,3 +49,7 @@ def on_head_network():
                ips[1] == '142' and
                ips[2] in ('52', '184'))  # 60 Garden, CDP respectively
     return out
+
+
+def is_32_bit():
+    return sys.maxsize <= 2 ** 32

--- a/testr/test_helper.py
+++ b/testr/test_helper.py
@@ -1,0 +1,50 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Provide helper functions that are useful for unit testing.
+"""
+
+import os
+from pathlib import Path
+import socket
+
+__all__ = ['has_sybase', 'on_head_network']
+
+
+def has_sybase():
+    """
+    Return True if the system apparently can run Sybase queries from Python.
+
+    In detail, this is True if the SYBASE and SYBASE_OCS env variables are set
+    and the correct Python shared object library exists on the system.
+    """
+    try:
+        path = Path(os.environ['SYBASE'],
+                    os.environ['SYBASE_OCS'],
+                    'python', 'python34_64r', 'lib', 'sybpydb.so')
+    except KeyError:
+        # If either env var not defined then there is no Sybase
+        out = False
+    else:
+        out = path.exists()
+
+    return out
+
+
+def on_head_network():
+    """
+    Return True if the system is apparently on the HEAD network.
+
+    This looks for subnets 52 (e.g. fido, lato) and 184 (kadi) on 131.142.xxx.
+    """
+    try:
+        hostname = socket.gethostname()
+        host_ip = socket.gethostbyname(hostname)
+    except Exception:
+        # If we cannot get a host_ip by this method then definitely not on HEAD.
+        out = False
+    else:
+        ips = host_ip.split('.')
+        out = (ips[0] == '131' and
+               ips[1] == '142' and
+               ips[2] in ('52', '184'))  # 60 Garden, CDP respectively
+    return out


### PR DESCRIPTION
## Testing: has_sybase and on_head_network

### MacOS laptop:
```
$ ipython
>>> from testr.test_helper import *
>>> has_sybase()
False
>>> on_head_network()
False
```
### kadi and fido
```
$ ipython
>>> from testr.test_helper import *
>>> has_sybase()
True
>>> on_head_network()
True
```
### c3po-v  56 subnet.  is this "on HEAD"?
```
$ ipython
>>> from testr.test_helper import *
>>> has_sybase()
True
>>> on_head_network()
False
```

## Testing: is_32_bit()

### MacOS laptop
```
In [1]: from testr.test_helper import *

In [2]: is_32_bit()
Out[2]: False
```


See https://github.com/sot/eng_archive/pull/175