### PR TITLE
Skare3 ci

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -162,24 +162,29 @@ Running the tests
 The ``run_testr`` command has the following options::
 
   $ run_testr --help
-  usage: run_testr [-h] [--test-spec TEST_SPEC_FILE] [--packages-dir PACKAGES_DIR]
-                   [--outputs-dir OUTPUTS_DIR] [--outputs-subdir OUTPUTS_SUBDIR]
-                   [--regress-dir REGRESS_DIR] [--include INCLUDES]
-                   [--exclude EXCLUDES] [--collect-only]
+  usage: run_testr [-h] [--test-spec TEST_SPEC] [--root ROOT]
+                   [--packages-dir PACKAGES_DIR] [--outputs-dir OUTPUTS_DIR]
+                   [--outputs-subdir OUTPUTS_SUBDIR] [--regress-dir REGRESS_DIR]
+                   [--include INCLUDES] [--exclude EXCLUDES] [--collect-only]
                    [--packages-repo PACKAGES_REPO] [--overwrite]
 
   optional arguments:
     -h, --help            show this help message and exit
-    --test-spec TEST_SPEC_FILE
-                          Test include/exclude specification file(default=None)
+    --test-spec TEST_SPEC
+                          Test include/exclude specification (default=None)
+    --root ROOT           Directory containing standard testr configuration
     --packages-dir PACKAGES_DIR
-                          Directory containing package tests
+                          Directory containing package tests. Absolute, or
+                          relative to --root
     --outputs-dir OUTPUTS_DIR
-                          Root directory containing all output package test runs
+                          Root directory containing all output package test
+                          runs. Absolute, or relative to CWD
     --outputs-subdir OUTPUTS_SUBDIR
-                          Directory containing per-run output package test runs
+                          Directory containing per-run output package test runs.
+                          Relative to --outputs-dir
     --regress-dir REGRESS_DIR
-                          Directory containing per-run regression files
+                          Directory containing per-run regression files.
+                          Relative to CWD
     --include INCLUDES    Include tests that match glob pattern
     --exclude EXCLUDES    Exclude tests that match glob pattern
     --collect-only        Collect tests but do not run
@@ -187,6 +192,12 @@ The ``run_testr`` command has the following options::
                           Base URL for package git repos
     --overwrite           Overwrite existing outputs directory instead of
                           deleting
+  usage: run_testr [-h] [--test-spec TEST_SPEC_FILE] [--packages-dir PACKAGES_DIR]
+                   [--outputs-dir OUTPUTS_DIR] [--outputs-subdir OUTPUTS_SUBDIR]
+                   [--regress-dir REGRESS_DIR] [--include INCLUDES]
+                   [--exclude EXCLUDES] [--collect-only]
+                   [--packages-repo PACKAGES_REPO] [--overwrite]
+
 
 For the example directory structure, doing ``run_testr`` (with no custom options) would
 run the tests, reporting test status for each test and then finish with a summary of test

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -246,12 +246,11 @@ the current directory or any sub-directories therein.  ::
 
       # Regression outputs, copied from outputs/ by post_regress* scripts
       regress/
-        0.18-r609-0d91665/
-          py_package/
-            out.dat             # Example data file from test_regress.sh
-            index.html          # Example web page from test_regress.sh
-          other_package/
-            big_data.dat        # More data
+        py_package/
+          out.dat             # Example data file from test_regress.sh
+          index.html          # Example web page from test_regress.sh
+        other_package/
+          big_data.dat        # More data
 
 Selecting tests
 ^^^^^^^^^^^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -164,8 +164,9 @@ The ``run_testr`` command has the following options::
   $ run_testr --help
   usage: run_testr [-h] [--test-spec TEST_SPEC] [--root ROOT]
                    [--packages-dir PACKAGES_DIR] [--outputs-dir OUTPUTS_DIR]
-                   [--outputs-subdir OUTPUTS_SUBDIR] [--regress-dir REGRESS_DIR]
-                   [--include INCLUDES] [--exclude EXCLUDES] [--collect-only]
+                   [--outputs-subdir OUTPUTS_SUBDIR] [--log-dir LOG_DIR]
+                   [--regress-dir REGRESS_DIR] [--include INCLUDES]
+                   [--exclude EXCLUDES] [--collect-only]
                    [--packages-repo PACKAGES_REPO] [--overwrite]
 
   optional arguments:
@@ -182,9 +183,11 @@ The ``run_testr`` command has the following options::
     --outputs-subdir OUTPUTS_SUBDIR
                           Directory containing per-run output package test runs.
                           Relative to --outputs-dir
+    --log-dir LOG_DIR     Directory containing per-run log files. Absolute, or
+                          relative to --outputs-subdir
     --regress-dir REGRESS_DIR
                           Directory containing per-run regression files.
-                          Relative to CWD
+                          Absolute, or relative to --outputs-subdir
     --include INCLUDES    Include tests that match glob pattern
     --exclude EXCLUDES    Exclude tests that match glob pattern
     --collect-only        Collect tests but do not run
@@ -192,11 +195,6 @@ The ``run_testr`` command has the following options::
                           Base URL for package git repos
     --overwrite           Overwrite existing outputs directory instead of
                           deleting
-  usage: run_testr [-h] [--test-spec TEST_SPEC_FILE] [--packages-dir PACKAGES_DIR]
-                   [--outputs-dir OUTPUTS_DIR] [--outputs-subdir OUTPUTS_SUBDIR]
-                   [--regress-dir REGRESS_DIR] [--include INCLUDES]
-                   [--exclude EXCLUDES] [--collect-only]
-                   [--packages-repo PACKAGES_REPO] [--overwrite]
 
 
 For the example directory structure, doing ``run_testr`` (with no custom options) would

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -173,7 +173,7 @@ The ``run_testr`` command has the following options::
                           Test include/exclude specification (default=None)
     --root ROOT           Directory containing standard testr configuration
     --outputs-dir OUTPUTS_DIR
-                          Root directory containing all output package test
+                          Directory containing all output package test
                           runs. Absolute, or relative to CWD
     --include INCLUDES    Include tests that match glob pattern
     --exclude EXCLUDES    Exclude tests that match glob pattern

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -163,9 +163,7 @@ The ``run_testr`` command has the following options::
 
   $ run_testr --help
   usage: run_testr [-h] [--test-spec TEST_SPEC] [--root ROOT]
-                   [--packages-dir PACKAGES_DIR] [--outputs-dir OUTPUTS_DIR]
-                   [--outputs-subdir OUTPUTS_SUBDIR] [--log-dir LOG_DIR]
-                   [--regress-dir REGRESS_DIR] [--include INCLUDES]
+                   [--outputs-dir OUTPUTS_DIR] [--include INCLUDES]
                    [--exclude EXCLUDES] [--collect-only]
                    [--packages-repo PACKAGES_REPO] [--overwrite]
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -220,35 +220,38 @@ the current directory or any sub-directories therein.  ::
 
   # Testing and post-process scripts and outputs
   outputs/
+    last -> 0.18-r609-0d91665
     0.18-r609-0d91665/
-      test.log              # Master log file of test processing and results
-      py_package/
-        helper_script.py
-        test_unit.py
-        test_unit.py.log    # Log file from running test_unit.py
-        test_regress.sh
-        test_regress.sh.log # Log file
-        post_regress.py
-        post_regress.py.log # Log file
-        post_check_logs.py
-        post_check_logs.py.log
-        out.dat             # Example data file from test_regress.sh
-        index.html          # Example web page from test_regress.sh
-      other_package/
-        test_regress_long.sh
-        test_regress_long.sh.log
-        post_regress_long.py
-        post_regress_long.py.log
-        big_data.dat        # More data
+      logs/
+        all_tests.json        # Master log file in JUnit's XML format
+        test.log              # Master log file of test processing and results
+        py_package/
+          helper_script.py
+          test_unit.py
+          test_unit.py.log    # Log file from running test_unit.py
+          test_regress.sh
+          test_regress.sh.log # Log file
+          post_regress.py
+          post_regress.py.log # Log file
+          post_check_logs.py
+          post_check_logs.py.log
+          out.dat             # Example data file from test_regress.sh
+          index.html          # Example web page from test_regress.sh
+        other_package/
+          test_regress_long.sh
+          test_regress_long.sh.log
+          post_regress_long.py
+          post_regress_long.py.log
+          big_data.dat        # More data
 
-  # Regression outputs, copied from outputs/ by post_regress* scripts
-  regress/
-    0.18-r609-0d91665/
-      py_package/
-        out.dat             # Example data file from test_regress.sh
-        index.html          # Example web page from test_regress.sh
-      other_package/
-        big_data.dat        # More data
+      # Regression outputs, copied from outputs/ by post_regress* scripts
+      regress/
+        0.18-r609-0d91665/
+          py_package/
+            out.dat             # Example data file from test_regress.sh
+            index.html          # Example web page from test_regress.sh
+          other_package/
+            big_data.dat        # More data
 
 Selecting tests
 ^^^^^^^^^^^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -435,6 +435,102 @@ package.  This one is slightly different because it generates new database
 values and then immediately compares with the current production database.
 
 
+Summary Logs
+^^^^^^^^^^^^
+
+Testr produces a summary log which includes all tests run. It parses the logs produced by pytest, and tests are grouped
+in suites following the test hierarchy. Tests that do not use pytest are grouped in a test suite at the top level.
+The log is written in JSON format and looks something like the following:
+
+.. code-block:: JSON
+
+    {
+      "test_suite": {
+        "name": "Quaternion-tests",
+        "package": "Quaternion",
+        "test_cases": [
+          {
+            "name": "post_check_logs.py",
+            "file": "Quaternion/post_check_logs.py",
+            "timestamp": "2020:06:16T09:43:13",
+            "log": "Quaternion/post_check_logs.py.log",
+            "status": "fail",
+            "failure": {
+              "message": "post_check_logs.py failed",
+              "output": null
+            }
+          }
+        ],
+        "timestamp": "2020:06:16T09:43:13",
+        "properties": {
+          "system": "Darwin",
+          "architecture": "64bit",
+          "hostname": "saos-MacBook-Pro.local",
+          "platform": "Darwin-19.5.0",
+          "package": "Quaternion",
+          "package_version": "3.5.2.dev9+g7ee8b10.d20200616",
+          "t_start": "2020:06:16T09:43:13",
+          "t_stop": "2020:06:16T09:43:14",
+          "regress_dir": null,
+          "out_dir": "Quaternion"
+        }
+      },
+      "test_suites": [
+        {
+          "test_cases": [
+            {
+              "name": "test_shape",
+              "classname": "Quaternion.tests.test_all",
+              "file": "Quaternion/tests/test_all.py",
+              "line": "43",
+              "status": "pass"
+            },
+            {
+              "name": "test_init_exceptions",
+              "classname": "Quaternion.tests.test_all",
+              "file": "Quaternion/tests/test_all.py",
+              "line": "50",
+              "failure": {
+                "message": "Exception: Unexpected exception here",
+                "output": "def test_init_exceptions():\n>       raise Exception('Unexpected exception here')\nE       Exception: Unexpected exception here\n\nQuaternion/tests/test_all.py:52: Exception"
+              },
+              "status": "fail"
+            },
+            {
+              "name": "test_from_q",
+              "classname": "Quaternion.tests.test_all",
+              "file": "Quaternion/tests/test_all.py",
+              "line": "83",
+              "skipped": {
+                "message": "no way of currently testing this",
+                "output": "Quaternion/tests/test_all.py:83: <py._xmlgen.raw object at 0x7f9ca044fb38>"
+              },
+              "status": "skipped"
+            }
+          ],
+          "name": "Quaternion-pytest",
+          "properties": {
+            "system": "Darwin",
+            "architecture": "64bit",
+            "hostname": "saos-MacBook-Pro.local",
+            "platform": "Darwin-19.5.0",
+            "package": "Quaternion",
+            "package_version": "3.5.2.dev9+g7ee8b10.d20200616",
+            "t_start": "2020:06:16T09:43:11",
+            "t_stop": "2020:06:16T09:43:13",
+            "regress_dir": null,
+            "out_dir": "Quaternion"
+          },
+          "log": "Quaternion/test_unit.py.log",
+          "hostname": "saos-MacBook-Pro.local",
+          "timestamp": "2020:06:16T09:43:11",
+          "package": "Quaternion",
+          "file": "Quaternion/test_unit.py"
+        }
+      ]
+    }
+
+
 Python testing helpers
 -----------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -180,14 +180,6 @@ The ``run_testr`` command has the following options::
     --outputs-dir OUTPUTS_DIR
                           Root directory containing all output package test
                           runs. Absolute, or relative to CWD
-    --outputs-subdir OUTPUTS_SUBDIR
-                          Directory containing per-run output package test runs.
-                          Relative to --outputs-dir
-    --log-dir LOG_DIR     Directory containing per-run log files. Absolute, or
-                          relative to --outputs-subdir
-    --regress-dir REGRESS_DIR
-                          Directory containing per-run regression files.
-                          Absolute, or relative to --outputs-subdir
     --include INCLUDES    Include tests that match glob pattern
     --exclude EXCLUDES    Exclude tests that match glob pattern
     --collect-only        Collect tests but do not run

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -174,9 +174,6 @@ The ``run_testr`` command has the following options::
     --test-spec TEST_SPEC
                           Test include/exclude specification (default=None)
     --root ROOT           Directory containing standard testr configuration
-    --packages-dir PACKAGES_DIR
-                          Directory containing package tests. Absolute, or
-                          relative to --root
     --outputs-dir OUTPUTS_DIR
                           Root directory containing all output package test
                           runs. Absolute, or relative to CWD

--- a/testr/packages.py
+++ b/testr/packages.py
@@ -430,7 +430,8 @@ def write_log(tests, include_stdout=False):
         'run_info': {
             'date': datetime.datetime.now().strftime('%Y:%m:%dT%H:%M:%S'),
             'argv': sys.argv,
-            'ska_version': ska_version
+            'ska_version': ska_version,
+            'test_spec': str(os.path.basename(opt.test_spec))
         }
     }
     if all_test_suites:

--- a/testr/packages.py
+++ b/testr/packages.py
@@ -577,9 +577,6 @@ def process_opt():
         sys.exit(1)
     outputs_subdir = bash(get_version_id)[0]
 
-    # if opt.log_dir and opt.regress_dir are absolute, then opt.outputs_dir means nothing
-    if os.path.isabs(opt.log_dir) and os.path.isabs(opt.regress_dir):
-        opt.outputs_dir = ''
     opt.log_dir = os.path.abspath(os.path.join(opt.outputs_dir,
                                                'logs',
                                                outputs_subdir))

--- a/testr/packages.py
+++ b/testr/packages.py
@@ -39,10 +39,6 @@ def get_options():
                         default=".",
                         help="Directory containing standard testr configuration",
                         )
-    parser.add_argument("--packages-dir",
-                        default="packages",
-                        help="Directory containing package tests. Absolute, or relative to --root",
-                        )
     parser.add_argument("--outputs-dir",
                         default="outputs",
                         help="Root directory containing all output package test runs."

--- a/testr/packages.py
+++ b/testr/packages.py
@@ -456,12 +456,11 @@ def make_test_dir():
     else:
         os.makedirs(test_dir)
 
-    if opt.outputs_dir and opt.outputs_subdir:
-        # Make a symlink 'last' to the most recent directory
-        with Ska.File.chdir(opt.outputs_dir):
-            if os.path.lexists('last'):
-                os.unlink('last')
-            os.symlink(opt.outputs_subdir, 'last')
+    # Make a symlink 'last' to the most recent directory
+    with Ska.File.chdir(os.path.dirname(opt.log_dir)):
+        if os.path.lexists('last'):
+            os.unlink('last')
+        os.symlink(os.path.basename(opt.log_dir), 'last')
 
     return test_dir
 
@@ -576,16 +575,15 @@ def process_opt():
         ska_version = bash(get_version_id)[0]
         opt.outputs_subdir = ska_version
 
-    # if opt.log_dir and are absolute, then opt.outputs_dir and opt.outputs_subdir mean nothing
+    # if opt.log_dir and are absolute, then opt.outputs_dir means nothing
     if os.path.isabs(opt.log_dir) and os.path.isabs(opt.regress_dir):
         opt.outputs_dir = ''
-        opt.outputs_subdir = ''
     opt.log_dir = os.path.abspath(os.path.join(opt.outputs_dir,
-                                               opt.outputs_subdir,
-                                               opt.log_dir))
+                                               opt.log_dir,
+                                               opt.outputs_subdir))
     opt.regress_dir = os.path.abspath(os.path.join(opt.outputs_dir,
-                                                   opt.outputs_subdir,
-                                                   opt.regress_dir))
+                                                   opt.regress_dir,
+                                                   opt.outputs_subdir))
 
     if opt.test_spec:
         if not os.path.exists(opt.test_spec):

--- a/testr/packages.py
+++ b/testr/packages.py
@@ -86,6 +86,10 @@ def get_options():
     if not os.path.isabs(opt.packages_dir):
         opt.packages_dir = os.path.join(opt.root, opt.packages_dir)
 
+    if os.path.isabs(opt.outputs_subdir):
+        get_logger().error('outputs-subdir must be a relative path')
+        parser.exit(1)
+
     return opt
 
 

--- a/testr/packages.py
+++ b/testr/packages.py
@@ -118,6 +118,11 @@ def collect_tests():
     for package in packages:
         tests[package] = []
 
+        try:
+            import ska_helpers
+            version = ska_helpers.get_version(package)
+        except:
+            version = 'unknown'
         in_dir = os.path.join(opt.packages_dir, package)
         out_dir = os.path.abspath(os.path.join(opt.outputs_dir, opt.outputs_subdir, package))
         regress_dir = os.path.abspath(os.path.join(opt.regress_dir, opt.outputs_subdir, package))
@@ -142,7 +147,8 @@ def collect_tests():
                         'out_dir': out_dir,
                         'regress_dir': regress_dir,
                         'packages_repo': opt.packages_repo,
-                        'package': package}
+                        'package': package,
+                        'package_version': version}
 
                 tests[package].append(test)
 

--- a/testr/packages.py
+++ b/testr/packages.py
@@ -345,7 +345,6 @@ def _rel_path_if_descendant(path, root):
 
 def write_log(tests, include_stdout=False):
     all_test_suites = []
-    top_testsuite = None
     outputs_subdir = os.path.join(opt.outputs_dir, opt.outputs_subdir)
 
     uname = platform.uname()
@@ -358,6 +357,8 @@ def write_log(tests, include_stdout=False):
     }
 
     for package in sorted(tests):
+        top_testsuite = None
+        package_test_suites = []
         for test in tests[package]:
             test_props = {k: (test[k] if k in test else None)
                           for k in ['package', 'package_version', 't_start', 't_stop']}
@@ -392,7 +393,7 @@ def write_log(tests, include_stdout=False):
                 if stdout:
                     # If len(test_suites) > 1, stdout is in the first suite
                     test_suites[0]['stdout'] = stdout
-                all_test_suites += test_suites
+                package_test_suites += test_suites
             else:
                 if top_testsuite is None:
                     properties = sys_info.copy()
@@ -426,9 +427,14 @@ def write_log(tests, include_stdout=False):
                     }
                 top_testsuite['test_cases'].append(test_case)
 
+        if len(package_test_suites) == 1:
+            package_test_suites[0]['test_cases'] += top_testsuite['test_cases']
+        else:
+            package_test_suites.append(top_testsuite)
+
+        all_test_suites += package_test_suites
+
     test_suites = {}
-    if top_testsuite:
-        test_suites['test_suite'] = top_testsuite
     if all_test_suites:
         test_suites['test_suites'] = all_test_suites
     outfile = os.path.join(outputs_subdir, f'all_tests.json')

--- a/testr/packages.py
+++ b/testr/packages.py
@@ -568,9 +568,7 @@ def process_opt():
     """
     # Set up directories
     opt.root = os.path.abspath(opt.root)
-    # the following line has no effect if opt.packages_dir is an absolute path
-    opt.packages_dir = os.path.join(opt.root, opt.packages_dir)
-
+    opt.packages_dir = os.path.join(opt.root, 'packages')
     get_version_id = os.path.join(opt.root, 'get_version_id')
     if not os.path.exists(get_version_id):
         get_logger().error(f'No get_version_id script in root directory: {opt.root}')
@@ -605,7 +603,7 @@ def process_opt():
                 else:
                     opt.includes.append(spec)
 
-    # If opt.includes is not expicitly initialized after processing test_spec (which is
+    # If opt.includes is not explicitly initialized after processing test_spec (which is
     # optional) then use ['*'] to include all tests
     opt.includes = opt.includes or ['*']
 

--- a/testr/packages.py
+++ b/testr/packages.py
@@ -556,9 +556,12 @@ def process_opt():
     if opt.outputs_subdir and os.path.isabs(opt.outputs_subdir):
         get_logger().error('outputs-subdir must be a relative path')
         sys.exit(1)
-
-    if opt.outputs_subdir is None:
-        ska_version = bash(os.path.join(opt.root, 'get_version_id'))[0]
+    elif opt.outputs_subdir is None:
+        get_version_id = os.path.join(opt.root, 'get_version_id')
+        if not os.path.exists(get_version_id):
+            get_logger().error(f'No get_version_id script in root directory: {opt.root}')
+            sys.exit(1)
+        ska_version = bash(get_version_id)[0]
         opt.outputs_subdir = ska_version
 
     if opt.test_spec:
@@ -570,7 +573,7 @@ def process_opt():
                 sys.exit(1)
         # This puts regression outputs into a separate sub-directory
         # and reads additional test file include/excludes.
-        opt.regress_dir = os.path.join(opt.regress_dir, opt.test_spec)
+        opt.regress_dir = os.path.join(opt.regress_dir, os.path.basename(opt.test_spec))
 
         with open('{}'.format(opt.test_spec), 'r') as fh:
             specs = (line.strip() for line in fh)

--- a/testr/packages.py
+++ b/testr/packages.py
@@ -86,7 +86,7 @@ def get_options():
     if not os.path.isabs(opt.packages_dir):
         opt.packages_dir = os.path.join(opt.root, opt.packages_dir)
 
-    if os.path.isabs(opt.outputs_subdir):
+    if opt.outputs_subdir and os.path.isabs(opt.outputs_subdir):
         get_logger().error('outputs-subdir must be a relative path')
         parser.exit(1)
 

--- a/testr/packages.py
+++ b/testr/packages.py
@@ -83,6 +83,7 @@ def get_options():
     parser.set_defaults()
 
     opt = parser.parse_args()
+    opt.root = os.path.abspath(opt.root)
     if not os.path.isabs(opt.packages_dir):
         opt.packages_dir = os.path.join(opt.root, opt.packages_dir)
 
@@ -561,6 +562,11 @@ def process_opt():
         opt.outputs_subdir = ska_version
 
     if opt.test_spec:
+        if not os.path.exists(opt.test_spec):
+            if os.path.exists(os.path.join(opt.root, opt.test_spec)):
+                opt.test_spec = os.path.join(opt.root, opt.test_spec)
+            else:
+                get_logger().error(f'test_spec file {opt.test_spec} does not exist')
         # This puts regression outputs into a separate sub-directory
         # and reads additional test file include/excludes.
         opt.regress_dir = os.path.join(opt.regress_dir, opt.test_spec)

--- a/testr/packages.py
+++ b/testr/packages.py
@@ -218,6 +218,8 @@ def get_results_table(tests):
     for package in sorted(tests):
         for test in tests[package]:
             results.append((package, test['file'], test['status']))
+    if len(results) == 0:
+        return
     out = Table(rows=results, names=('Package', 'Script', 'Status'))
     return out
 
@@ -378,4 +380,5 @@ def main():
             run_tests(package, tests[package])  # updates tests[package] in place
 
     results = get_results_table(tests)
-    box_output(results.pformat(max_lines=-1, max_width=-1))
+    if results:
+        box_output(results.pformat(max_lines=-1, max_width=-1))

--- a/testr/packages.py
+++ b/testr/packages.py
@@ -82,16 +82,7 @@ def get_options():
                         )
     parser.set_defaults()
 
-    opt = parser.parse_args()
-    opt.root = os.path.abspath(opt.root)
-    if not os.path.isabs(opt.packages_dir):
-        opt.packages_dir = os.path.join(opt.root, opt.packages_dir)
-
-    if opt.outputs_subdir and os.path.isabs(opt.outputs_subdir):
-        get_logger().error('outputs-subdir must be a relative path')
-        parser.exit(1)
-
-    return opt
+    return parser.parse_args()
 
 
 class Tee(object):
@@ -557,6 +548,14 @@ def process_opt():
     convenience.
     """
     # Set up directories
+    opt.root = os.path.abspath(opt.root)
+    if not os.path.isabs(opt.packages_dir):
+        opt.packages_dir = os.path.join(opt.root, opt.packages_dir)
+
+    if opt.outputs_subdir and os.path.isabs(opt.outputs_subdir):
+        get_logger().error('outputs-subdir must be a relative path')
+        sys.exit(1)
+
     if opt.outputs_subdir is None:
         ska_version = bash(os.path.join(opt.root, 'get_version_id'))[0]
         opt.outputs_subdir = ska_version
@@ -567,6 +566,7 @@ def process_opt():
                 opt.test_spec = os.path.join(opt.root, opt.test_spec)
             else:
                 get_logger().error(f'test_spec file {opt.test_spec} does not exist')
+                sys.exit(1)
         # This puts regression outputs into a separate sub-directory
         # and reads additional test file include/excludes.
         opt.regress_dir = os.path.join(opt.regress_dir, opt.test_spec)

--- a/testr/packages.py
+++ b/testr/packages.py
@@ -359,7 +359,8 @@ def write_log(tests, include_stdout=False):
 
     for package in sorted(tests):
         for test in tests[package]:
-            test_props = {k: test[k] for k in ['package', 'package_version', 't_start', 't_stop']}
+            test_props = {k: (test[k] if k in test else None)
+                          for k in ['package', 'package_version', 't_start', 't_stop']}
             for k in ['regress_dir', 'out_dir']:
                 test_props[k] = _rel_path_if_descendant(test[k], outputs_subdir)
 
@@ -400,14 +401,14 @@ def write_log(tests, include_stdout=False):
                         name=f"{package}-tests",
                         package=package,
                         test_cases=[],
-                        timestamp=test['t_start'],
+                        timestamp=test_props['t_start'],
                         properties=properties
                     )
                 test_status = {'pass': 'pass', 'fail': 'fail', '----': 'skipped'}
                 test_case = dict(
                     name=test['file'],
                     file=test_file,
-                    timestamp=test['t_start'],
+                    timestamp=test_props['t_start'],
                     log=log_file,
                     status=test_status[test['status'].lower()]
                 )

--- a/testr/packages.py
+++ b/testr/packages.py
@@ -48,20 +48,6 @@ def get_options():
                         help="Root directory containing all output package test runs."
                              " Absolute, or relative to CWD",
                         )
-    parser.add_argument("--outputs-subdir",
-                        help="Directory containing per-run output package test runs."
-                             " Relative to --outputs-dir",
-                        )
-    parser.add_argument("--log-dir",
-                        default="logs",
-                        help="Directory containing per-run log files."
-                             " Absolute, or relative to --outputs-subdir",
-                        )
-    parser.add_argument("--regress-dir",
-                        default="regress",
-                        help="Directory containing per-run regression files."
-                             " Absolute, or relative to --outputs-subdir",
-                        )
     parser.add_argument('--include',
                         action='append',
                         default=[],
@@ -585,26 +571,21 @@ def process_opt():
     # the following line has no effect if opt.packages_dir is an absolute path
     opt.packages_dir = os.path.join(opt.root, opt.packages_dir)
 
-    if opt.outputs_subdir and os.path.isabs(opt.outputs_subdir):
-        get_logger().error('outputs-subdir must be a relative path')
+    get_version_id = os.path.join(opt.root, 'get_version_id')
+    if not os.path.exists(get_version_id):
+        get_logger().error(f'No get_version_id script in root directory: {opt.root}')
         sys.exit(1)
-    elif opt.outputs_subdir is None:
-        get_version_id = os.path.join(opt.root, 'get_version_id')
-        if not os.path.exists(get_version_id):
-            get_logger().error(f'No get_version_id script in root directory: {opt.root}')
-            sys.exit(1)
-        ska_version = bash(get_version_id)[0]
-        opt.outputs_subdir = ska_version
+    outputs_subdir = bash(get_version_id)[0]
 
     # if opt.log_dir and opt.regress_dir are absolute, then opt.outputs_dir means nothing
     if os.path.isabs(opt.log_dir) and os.path.isabs(opt.regress_dir):
         opt.outputs_dir = ''
     opt.log_dir = os.path.abspath(os.path.join(opt.outputs_dir,
-                                               opt.log_dir,
-                                               opt.outputs_subdir))
+                                               'logs',
+                                               outputs_subdir))
     opt.regress_dir = os.path.abspath(os.path.join(opt.outputs_dir,
-                                                   opt.regress_dir,
-                                                   opt.outputs_subdir))
+                                                   'regress',
+                                                   outputs_subdir))
 
     if opt.test_spec:
         if not os.path.exists(opt.test_spec):

--- a/testr/packages.py
+++ b/testr/packages.py
@@ -596,7 +596,7 @@ def process_opt():
         ska_version = bash(get_version_id)[0]
         opt.outputs_subdir = ska_version
 
-    # if opt.log_dir and are absolute, then opt.outputs_dir means nothing
+    # if opt.log_dir and opt.regress_dir are absolute, then opt.outputs_dir means nothing
     if os.path.isabs(opt.log_dir) and os.path.isabs(opt.regress_dir):
         opt.outputs_dir = ''
     opt.log_dir = os.path.abspath(os.path.join(opt.outputs_dir,

--- a/testr/packages.py
+++ b/testr/packages.py
@@ -447,7 +447,7 @@ def make_test_dir():
 
     # Make a symlink 'last' to the most recent directory
     with Ska.File.chdir(opt.outputs_dir):
-        if os.path.exists('last'):
+        if os.path.lexists('last'):
             os.unlink('last')
         os.symlink(opt.outputs_subdir, 'last')
 

--- a/testr/packages.py
+++ b/testr/packages.py
@@ -32,20 +32,27 @@ def get_options():
     parser.add_argument("--test-spec",
                         help="Test include/exclude specification (default=None)",
                         )
+    parser.add_argument("--root",
+                        default=".",
+                        help="Directory containing standard testr configuration",
+                        )
     parser.add_argument("--packages-dir",
                         default="packages",
-                        help="Directory containing package tests",
+                        help="Directory containing package tests. Absolute, or relative to --root",
                         )
     parser.add_argument("--outputs-dir",
                         default="outputs",
-                        help="Root directory containing all output package test runs",
+                        help="Root directory containing all output package test runs."
+                             " Absolute, or relative to CWD",
                         )
     parser.add_argument("--outputs-subdir",
-                        help="Directory containing per-run output package test runs",
+                        help="Directory containing per-run output package test runs."
+                             " Relative to --outputs-dir",
                         )
     parser.add_argument("--regress-dir",
                         default="regress",
-                        help="Directory containing per-run regression files",
+                        help="Directory containing per-run regression files."
+                             " Relative to CWD",
                         )
     parser.add_argument('--include',
                         action='append',
@@ -73,7 +80,11 @@ def get_options():
                         )
     parser.set_defaults()
 
-    return parser.parse_args()
+    opt = parser.parse_args()
+    if not os.path.isabs(opt.packages_dir):
+        opt.packages_dir = os.path.join(opt.root, opt.packages_dir)
+
+    return opt
 
 
 class Tee(object):
@@ -483,7 +494,7 @@ def process_opt():
     """
     # Set up directories
     if opt.outputs_subdir is None:
-        ska_version = bash('./get_version_id')[0]
+        ska_version = bash(os.path.join(opt.root, 'get_version_id'))[0]
         opt.outputs_subdir = ska_version
 
     if opt.test_spec:

--- a/testr/packages.py
+++ b/testr/packages.py
@@ -576,7 +576,6 @@ def process_opt():
         get_logger().error(f'No get_version_id script in root directory: {opt.root}')
         sys.exit(1)
     outputs_subdir = bash(get_version_id)[0]
-
     opt.log_dir = os.path.abspath(os.path.join(opt.outputs_dir,
                                                'logs',
                                                outputs_subdir))

--- a/testr/runner.py
+++ b/testr/runner.py
@@ -106,6 +106,10 @@ def test(*args, **kwargs):
 
     args = args + PYTEST_IGNORE_WARNINGS
 
+    if 'TESTR_OUT_DIR' in os.environ and 'TESTR_FILE' in os.environ:
+        report_file = os.path.join(os.environ['TESTR_OUT_DIR'], f"{os.environ['TESTR_FILE']}.xml")
+        args += (f'--junit-xml={report_file}',)
+
     stack_level = kwargs.pop('stack_level', 1)
     calling_frame_record = inspect.stack()[stack_level]  # Only works for stack-based Python
     calling_func_file = calling_frame_record[1]

--- a/testr/runner.py
+++ b/testr/runner.py
@@ -113,7 +113,7 @@ def test(*args, **kwargs):
     if 'TESTR_OUT_DIR' in os.environ and 'TESTR_FILE' in os.environ:
         report_file = os.path.join(os.environ['TESTR_OUT_DIR'], f"{os.environ['TESTR_FILE']}.xml")
         args += (f'--junit-xml={report_file}',)
-        args += ('-o', 'junit_family=xunit1')
+        args += ('-o', 'junit_family=xunit2')
 
     stack_level = kwargs.pop('stack_level', 1)
     calling_frame_record = inspect.stack()[stack_level]  # Only works for stack-based Python

--- a/testr/runner.py
+++ b/testr/runner.py
@@ -113,6 +113,7 @@ def test(*args, **kwargs):
     if 'TESTR_OUT_DIR' in os.environ and 'TESTR_FILE' in os.environ:
         report_file = os.path.join(os.environ['TESTR_OUT_DIR'], f"{os.environ['TESTR_FILE']}.xml")
         args += (f'--junit-xml={report_file}',)
+        args += ('-o', 'junit_family=xunit1')
 
     stack_level = kwargs.pop('stack_level', 1)
     calling_frame_record = inspect.stack()[stack_level]  # Only works for stack-based Python

--- a/testr/runner.py
+++ b/testr/runner.py
@@ -99,9 +99,13 @@ def test(*args, **kwargs):
     package_from_dir = kwargs.pop('package_from_dir', False)
     get_version = kwargs.pop('get_version', False)
 
-    if kwargs.pop('verbose', False) and '-v' not in args:
+    if 'TESTR_PYTEST_ARGS' in os.environ:
+        args = args + tuple(os.environ['TESTR_PYTEST_ARGS'].split())
+
+    arg_names = [a.split('=')[0] for a in args]
+    if kwargs.pop('verbose', False) and '-v' not in args and '-q' not in arg_names:
         args = args + ('-v',)
-    if kwargs.pop('show_output', False) and '-s' not in args:
+    if kwargs.pop('show_output', False) and '-s' not in args and '--capture' not in arg_names:
         args = args + ('-s',)
 
     args = args + PYTEST_IGNORE_WARNINGS


### PR DESCRIPTION
## Description

This PR makes some changes that are convenient within the CI process:
- add a --root argument to testr so one can run it from a different directory than the config directory
- output a comprehensive machine-readable log file at the end of the run
- include some meta data in log file (start/stop time, system info, package versions)
- add a way to pass options to pytest using an environmental variable.

[Documentation can temporarily be found here](https://cxc.cfa.harvard.edu/mta/ASPECT/tmp/jgonzalez/docs/testr_docs/).

After this PR, testr will not work with ska_helpers version 0.1.1 or earlier.

## Note

There is an inherent inconsistency that comes from using testr to begin with. When a pytest test is skipped, all the test cases in there are not reported as skipped. All test suites in there are also not reported. The whole file is reported as a single test case. On the other hand, if it is run, then it is reported as a test suite, and all test cases are reported. This really bugs me.

I can (and will) use some heuristics downstream to figure out whether a given test was actually a test suite. This is not ideal.

## Interface impact

This PR introduces a change in behavior. It introduces the `--root` option, which allows testr to be called from a different directory than its configuration directory.

Before this PR:
- The `--packages-dir`, `--outputs-dir` and `--regress-dir` were implicitly interpreted either as absolute paths, or as paths relative to the configuration directory (same as the working directory).
- The `--outputs-subdir` was assumed to be a relative path, but a user could actually provide an absolute path.

After this PR:
- `--outputs-subdir` is gone. outputs-subdir is always given by the get_version script.
- `--regress-dir` is gone. Now there are two directories within outputs-subdir: logs and regress.
- `--packages-dir` is gone. It is allways join(outputs-subdir, 'packages')

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required). **This package still needs unit tests, but they are not being added in this PR.**
- [x] Functional testing. Running with the following argument combinations (of the relevant arguments)
  - [x] none
  - [x] `--root`
  - [x] `--root` and `--outputs-dir`
  - [x] `--root $ROOT --test-spec test_spec_Ska.ftp`
  - [x] `--root $ROOT --include dea_check --outputs-dir junk2 (for regress)
  - [x] `--root $ROOT --test-spec test_spec_SKA3_HEAD`