### PR TITLE
Ignore certain warnings and supply pytest args as list not string

### DIFF
--- a/testr/runner.py
+++ b/testr/runner.py
@@ -7,6 +7,20 @@ Provide a test() function that can be called from package __init__.
 import os
 
 
+# Pytest args for main() to ignore several warnings that show up regularly in
+# testing but can be ignored.
+PYTEST_IGNORE_WARNINGS = (
+    # See https://github.com/numpy/numpy/issues/11788 for why the numpy.ufunc
+    # warning is apparently OK.
+    '-Wignore:numpy.ufunc size changed:RuntimeWarning',
+
+    # Shows up in upstream packages including ipyparallel
+    '-Wignore:the imp module is deprecated in favour of importlib:DeprecationWarning',
+
+    # Shows up in setuptools_scm
+    '-Wignore:parse functions are required to provide a named:PendingDeprecationWarning')
+
+
 class TestError(Exception):
     pass
 
@@ -89,6 +103,8 @@ def test(*args, **kwargs):
         args = args + ('-v',)
     if kwargs.pop('show_output', False) and '-s' not in args:
         args = args + ('-s',)
+
+    args = args + PYTEST_IGNORE_WARNINGS
 
     stack_level = kwargs.pop('stack_level', 1)
     calling_frame_record = inspect.stack()[stack_level]  # Only works for stack-based Python

--- a/testr/setup_helper.py
+++ b/testr/setup_helper.py
@@ -24,7 +24,13 @@ class PyTest(TestCommand):
     def run_tests(self):
         # Import here because outside the eggs aren't loaded
         import pytest
-        errno = pytest.main(self.args)
+        import shlex
+        from .runner import PYTEST_IGNORE_WARNINGS
+
+        args = list(PYTEST_IGNORE_WARNINGS)
+        if self.args:
+            args += shlex.split(self.args)
+        errno = pytest.main(args)
         sys.exit(errno)
 
 


### PR DESCRIPTION
## Description

This ignores 3 particular warnings that show up in testing and cause ska_testr fails. The warnings and reasoning are documented in the code.

It also updates handing of args in something like `pytest setup.py test --args='-k test_blah -v'`.  This previously passed that string to pytest, which had been raising a deprecation warning but is now failing in pytest 5.4.

## Testing

- [N/A] Passes unit tests
- [x] Functional testing

The following testing was done for `ska3-shiny` and `ska3-flight` environments.  In both cases
I put this version of `testr` into `PYTHONPATH` and then did the following testing for the package Chandra.Maneuver that shows at 2 of the warnings. This had previously been failing the ska_testr in shiny because of the warnings.

In the git repo for Chandra.Maneuver I moved `pytest.ini` away for testing to be sure that is not influencing the results.

The point to note in the test logs below is the absence of any warnings in the pytest output.

### ska_testr

```
****************************************
*** package Chandra.Maneuver         ***
****************************************

Removing existing output dir outputs/521b6c1_Darwin_x86_64_daze.local/Chandra.Maneuver
Copying input tests packages/Chandra.Maneuver to output dir outputs/521b6c1_Darwin_x86_64_daze.local/Chandra.Maneuver
Running python test_unit.py script
Bash-08:07:22> export TESTR_FILE='test_unit.py'
Bash-08:07:22> export TESTR_STATUS='not run'
Bash-08:07:22> export TESTR_INTERPRETER='python'
Bash-08:07:22> export TESTR_OUT_DIR='/Users/aldcroft/git/ska_testr/outputs/521b6c1_Darwin_x86_64_daze.local/Chandra.Maneuver'
Bash-08:07:22> export TESTR_REGRESS_DIR='/Users/aldcroft/git/ska_testr/regress/521b6c1_Darwin_x86_64_daze.local/Chandra.Maneuver'
Bash-08:07:22> export TESTR_PACKAGES_REPO='https://github.com/sot'
Bash-08:07:22> export TESTR_PACKAGE='Chandra.Maneuver'
Bash-08:07:22> python test_unit.py
============================= test session starts ==============================
platform darwin -- Python 3.6.10, pytest-5.4.2, py-1.8.1, pluggy-0.13.1 -- /Users/aldcroft/miniconda3/envs/ska3-shiny/bin/python
cachedir: .pytest_cache
rootdir: /Users/aldcroft/miniconda3/envs/ska3-shiny/lib/python3.6/site-packages
collected 4 items                                                              

Chandra/Maneuver/tests/test_maneuver.py::test_attitudes PASSED
Chandra/Maneuver/tests/test_maneuver.py::test_versus_telemetry PASSED
Chandra/Maneuver/tests/test_maneuver.py::test_inject_errors PASSED
Chandra/Maneuver/tests/test_maneuver.py::test_inject_array_errors PASSED

============================== 4 passed in 0.83s ===============================
Bash-08:07:23> 
Running python post_check_logs.py script
Bash-08:07:23> export TESTR_FILE='post_check_logs.py'
Bash-08:07:23> export TESTR_STATUS='not run'
Bash-08:07:23> export TESTR_INTERPRETER='python'
Bash-08:07:23> export TESTR_OUT_DIR='/Users/aldcroft/git/ska_testr/outputs/521b6c1_Darwin_x86_64_daze.local/Chandra.Maneuver'
Bash-08:07:23> export TESTR_REGRESS_DIR='/Users/aldcroft/git/ska_testr/regress/521b6c1_Darwin_x86_64_daze.local/Chandra.Maneuver'
Bash-08:07:23> export TESTR_PACKAGES_REPO='https://github.com/sot'
Bash-08:07:23> export TESTR_PACKAGE='Chandra.Maneuver'
Bash-08:07:23> python post_check_logs.py
Bash-08:07:24> 
****************************************
*** Chandra.Maneuver Test Summary    ***
*** test_unit.py         pass        ***
*** post_check_logs.py   pass        ***
****************************************
```

### python setup.py test
```
(ska3-shiny) ➜  Chandra.Maneuver git:(master) ✗ python setup.py test 
running test
WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
running egg_info
writing Chandra.Maneuver.egg-info/PKG-INFO
writing dependency_links to Chandra.Maneuver.egg-info/dependency_links.txt
writing requirements to Chandra.Maneuver.egg-info/requires.txt
writing top-level names to Chandra.Maneuver.egg-info/top_level.txt
package init file 'Chandra/__init__.py' not found (or not a regular file)
writing manifest file 'Chandra.Maneuver.egg-info/SOURCES.txt'
running build_ext
========================================================== test session starts ==========================================================
platform darwin -- Python 3.6.10, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
rootdir: /Users/aldcroft/git/Chandra.Maneuver
collected 4 items                                                                                                                       

Chandra/Maneuver/tests/test_maneuver.py ....                                                                                      [100%]

=========================================================== 4 passed in 1.04s ===========================================================
```
### python setup.py test --args='-v -k versus'
```
(ska3-shiny) ➜  Chandra.Maneuver git:(master) ✗ python setup.py test --args='-v -k versus'
running test
WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
running egg_info
writing Chandra.Maneuver.egg-info/PKG-INFO
writing dependency_links to Chandra.Maneuver.egg-info/dependency_links.txt
writing requirements to Chandra.Maneuver.egg-info/requires.txt
writing top-level names to Chandra.Maneuver.egg-info/top_level.txt
package init file 'Chandra/__init__.py' not found (or not a regular file)
writing manifest file 'Chandra.Maneuver.egg-info/SOURCES.txt'
running build_ext
========================================================== test session starts ==========================================================
platform darwin -- Python 3.6.10, pytest-5.4.2, py-1.8.1, pluggy-0.13.1 -- /Users/aldcroft/miniconda3/envs/ska3-shiny/bin/python
cachedir: .pytest_cache
rootdir: /Users/aldcroft/git/Chandra.Maneuver
collected 4 items / 3 deselected / 1 selected                                                                                           

Chandra/Maneuver/tests/test_maneuver.py::test_versus_telemetry PASSED                                                             [100%]

==================================================== 1 passed, 3 deselected in 1.01s ====================================================
```

### python -c 'import Chandra.Maneuver; Chandra.Maneuver.test()'
```
(ska3-shiny) ➜  Chandra.Maneuver git:(master) ✗ cd
(ska3-shiny) ➜  ~ python -c 'import Chandra.Maneuver; Chandra.Maneuver.test()'
========================================================== test session starts ==========================================================
platform darwin -- Python 3.6.10, pytest-5.4.2, py-1.8.1, pluggy-0.13.1
rootdir: /Users/aldcroft/miniconda3/envs/ska3-shiny/lib/python3.6/site-packages
collected 4 items                                                                                                                       

Chandra/Maneuver/tests/test_maneuver.py ....                                                                                      [100%]

=========================================================== 4 passed in 1.02s ===========================================================
```
### python -c "import Chandra.Maneuver; Chandra.Maneuver.test('-v', '-k', 'versus')"
```
(ska3-shiny) ➜  ~ python -c "import Chandra.Maneuver; Chandra.Maneuver.test('-v', '-k', 'versus')"
========================================================== test session starts ==========================================================
platform darwin -- Python 3.6.10, pytest-5.4.2, py-1.8.1, pluggy-0.13.1 -- /Users/aldcroft/miniconda3/envs/ska3-shiny/bin/python
cachedir: .pytest_cache
rootdir: /Users/aldcroft/miniconda3/envs/ska3-shiny/lib/python3.6/site-packages
collected 4 items / 3 deselected / 1 selected                                                                                           

Chandra/Maneuver/tests/test_maneuver.py::test_versus_telemetry PASSED                                                             [100%]

==================================================== 1 passed, 3 deselected in 0.78s ====================================================
```
