### PR TITLE
Disable caching of test results

### DIFF
--- a/testr/runner.py
+++ b/testr/runner.py
@@ -115,6 +115,10 @@ def test(*args, **kwargs):
         args += (f'--junit-xml={report_file}',)
         args += ('-o', 'junit_family=xunit2')
 
+    # Disable caching of test results to prevent users trying to write into
+    # flight directory if tests fail running on installed package.
+    args = args + ('-p', 'no:cacheprovider')
+
     stack_level = kwargs.pop('stack_level', 1)
     calling_frame_record = inspect.stack()[stack_level]  # Only works for stack-based Python
     calling_func_file = calling_frame_record[1]


### PR DESCRIPTION
## Description

Disable caching of test results to prevent users trying to write into flight directory if tests fail running on installed package. 

I think this impacts `python setup.py test` also (but not 100% sure) but not direct `pytest` (which doesn't work for namespace packages unfortunately).

## Testing

- [N/A] Passes unit tests (no tests)
- [x] Functional testing

Running `run_testr` as user `aldcroft` in ska3-shiny on HEAD produces pytest warnings for every unit test because it is trying to write to cache info to /proj/sot/ska3/shiny. I applied this patch as a hot-fix to ska3-shiny on HEAD and confirmed that all those warnings go away and tests still run as expected.