### PR TITLE
Support running with no --test-spec

### DIFF
--- a/testr/packages.py
+++ b/testr/packages.py
@@ -431,7 +431,7 @@ def write_log(tests, include_stdout=False):
             'date': datetime.datetime.now().strftime('%Y:%m:%dT%H:%M:%S'),
             'argv': sys.argv,
             'ska_version': ska_version,
-            'test_spec': str(os.path.basename(opt.test_spec))
+            'test_spec': os.path.basename(str(opt.test_spec))
         }
     }
     if all_test_suites:


### PR DESCRIPTION
## Description

Looks like an order mix-up in coercing `opt.test_spec` to string for serialization.

## Testing

- [N/A] Passes unit tests (no tests)
- [x] Functional testing

Ran `env PYTHONPATH=$PWD run_testr --include agasc --root ~/git/ska_testr` within testr git repo and confirm that run succeeded and that the output in `outputs/logs/last/all_tests.json` is expected: 
```
...
    "ska_version": "e18efa3",
    "test_spec": "None",
    "t_stop": "2020:07:24T09:21:34",
    "t_start": "2020:07:24T09:21:26",
...
```