### PR TITLE
Ignore bleach warning

### DIFF
--- a/testr/packages.py
+++ b/testr/packages.py
@@ -627,3 +627,7 @@ def main():
         box_output(results.pformat(max_lines=-1, max_width=-1))
 
     write_log(tests)
+
+
+if __name__ == '__main__':
+    main()

--- a/testr/runner.py
+++ b/testr/runner.py
@@ -18,7 +18,10 @@ PYTEST_IGNORE_WARNINGS = (
     '-Wignore:the imp module is deprecated in favour of importlib:DeprecationWarning',
 
     # Shows up in setuptools_scm
-    '-Wignore:parse functions are required to provide a named:PendingDeprecationWarning')
+    '-Wignore:parse functions are required to provide a named:PendingDeprecationWarning',
+
+    # Shows up in sparkles from importing bleach
+    '-Wignore:Using or importing the ABCs:DeprecationWarning')
 
 
 class TestError(Exception):


### PR DESCRIPTION
## Description

This is to ignore a deprecation warning that was causing a post_check fail for sparkles. This was coming from `bleach`.

In order to easily test this I needed to make the `packages` module runnable with `python -m ..`.

## Testing

- [N/A] No unit tests
- [x] Functional testing

Used this version and confirmed that the warning no longer appears in `ska_testr` with `python -m testr.packages --include sparkles`.