### PR TITLE
Support Windows for package testing

### DIFF
--- a/testr/packages.py
+++ b/testr/packages.py
@@ -184,9 +184,8 @@ def run_tests(package, tests):
     with Ska.File.chdir(out_dir):
         for test in include_tests:
             # Make the test keys available in the environment
-            env = os.environ.copy()
-            env.update({'TESTR_{}'.format(str(key).upper()): str(val)
-                        for key, val in test.items()})
+            env = {'TESTR_{}'.format(str(key).upper()): str(val)
+                   for key, val in test.items()}
 
             interpreter = test['interpreter']
 
@@ -204,6 +203,9 @@ def run_tests(package, tests):
             test['t_start'] = datetime.datetime.now().strftime('%Y:%m:%dT%H:%M:%S')
 
             if IS_WINDOWS:
+                # Need full environment in the subprocess run
+                env.update(os.environ)
+
                 cmds = [sys.executable, test['file']]
                 try:
                     sub = subprocess.run(cmds, env=env, stdout=logfile)


### PR DESCRIPTION
## Description

This makes the `testr` + `ska_testr` pair work on Windows. Key changes:

- Use `subprocess.run` for testing on Windows, but still use `pexpect` on linux / Mac to support bash test scripts (and for consistency with historical behavior).
- Drop support for overwriting an existing test output directory. I don't think this was being used. This change was needed to get rid of a call to rsync.
- Drop support for a `get_version_id` bash script that makes the test directory name. Instead just hardwire something reasonable into `testr`.
  - Note that a path name that includes colons breaks both Windows and the Ska.engarchive regression test, so colon is changed to dash.
- PEP8 fixes.

## Testing

- [N/A] Passes unit tests on MacOS, linux, Windows.
- [x] Functional testing

### Functional testing

#### Windows

The following runs to completion and gives the expected results. There are some fails that have the correct diagnostic information and passes that look good.
```
python -m testr.packages --root C:\Users\aldcroft\git/ska_testr --test-spec=test_spec_SKA3
```
I did not verify the output of the XML test results. Most likely things are OK, but this will be done as part of getting automated Windows CI running.

#### Linux (HEAD)

The following runs to completion and gives the expected results.
```
python -m testr.packages --root ~/git/ska_testr --include=agasc --include=Ska.engarchive --include=acisfp_check
```

Fixes #31