### PR TITLE
WIP: pass bash-history environment variables to child processes

### DIFF
--- a/testr/packages.py
+++ b/testr/packages.py
@@ -282,6 +282,13 @@ def run_tests(package, tests):
                     cmd = interpreter + ' ' + test['file']
 
                 try:
+                    env.update(
+                        {
+                            k: os.environ[k]
+                            for k in ['HISTSIZE', 'HISTFILESIZE', 'HISTIGNORE', 'HISTCONTROL']
+                            if k in os.environ
+                        }
+                    )
                     bash(cmd, logfile=logfile, env=env)
                 except ShellError:
                     # Test process returned a non-zero status => Fail


### PR DESCRIPTION
## Description

This change is to make sure the bash shell customizations are included in child processes.
- In my own bashrc, I have set the history length to something larger than the default, and currently the history file is truncated whenever testr is run.
- I run regression tests daily, so my history is poluted with things like this:
   ```
  463  export TESTR_FILE='post_check_logs.py'
  464  export TESTR_STATUS='not run'
  465  export TESTR_INTERPRETER='python'
  466  export TESTR_OUT_DIR='/proj/sot/ska/jgonzalez/git/ska_testr/outputs/logs/Linux_2021-08-03T12-42-49_2021.81005369_kady.cfa.harvard.edu/Quaternion'
  467  export TESTR_REGRESS_DIR='/proj/sot/ska/jgonzalez/git/ska_testr/outputs/regress/Linux_2021-08-03T12-42-49_2021.8-1005369_kady.cfa.harvard.edu/Quaternion'
  468  export TESTR_PACKAGES_REPO='https://github.com/sot'
  469  export TESTR_PACKAGE='Quaternion'
  470  export TESTR_PACKAGE_VERSION='3.6.0'
  471  python post_check_logs.py
  472  echo $?
   ```

The default length of the history file, combined with the lines from testr, means my bash history is completely useless.

I am not sure this is the way to do it, especially because sometimes I get this in my history and sometimes I don't. Is there a better way?

## Testing

- [ ] Passes unit tests on MacOS, linux, Windows (at least one required)
- [ ] Functional testing

Fixes #