### PR TITLE
Ignore deprecation warning that comes from external packages

### DIFF
--- a/testr/runner.py
+++ b/testr/runner.py
@@ -29,23 +29,9 @@ PYTEST_IGNORE_WARNINGS = (
     # This warning comes about when running with the latest version MarksupSafe (>=2.0) but an old version of Jinja2<3.0.
     "-Wignore: 'soft_unicode' has been renamed to 'soft_str'",
 
-    # acis_thermal_check/utils.py:164
-    # acis_thermal_check/utils.py:269
-    # acis_thermal_check/utils.py:290
-    # acis_thermal_check/utils.py:272
-    # Ska/Matplotlib/core.py:145
-    "-Wignore: linestyle is redundantly defined by the 'linestyle' keyword argument and the fmt string",
-
-    # Ska/Matplotlib/core.py:145
-    "-Wignore: color is redundantly defined by the 'color' keyword argument and the fmt string",
-
     # annie/telem.py:18
     #  (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
     "-Wignore:  Creating an ndarray from ragged nested sequences",
-
-    # proseco/report_acq.py:477
-    # proseco/report_acq.py:480
-    "-Wignore: FixedFormatter should only be used together with FixedLocator",
     )
 
 

--- a/testr/runner.py
+++ b/testr/runner.py
@@ -34,7 +34,10 @@ PYTEST_IGNORE_WARNINGS = (
     # acis_thermal_check/utils.py:290
     # acis_thermal_check/utils.py:272
     # Ska/Matplotlib/core.py:145
-    "-Wignore: linestyle is redundantly defined by the 'linestyle' keyword",
+    "-Wignore: linestyle is redundantly defined by the 'linestyle' keyword argument and the fmt string",
+
+    # Ska/Matplotlib/core.py:145
+    "-Wignore: color is redundantly defined by the 'color' keyword argument and the fmt string",
 
     # annie/telem.py:18
     #  (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.

--- a/testr/runner.py
+++ b/testr/runner.py
@@ -21,7 +21,11 @@ PYTEST_IGNORE_WARNINGS = (
     '-Wignore:parse functions are required to provide a named:PendingDeprecationWarning',
 
     # Shows up in sparkles from importing bleach
-    '-Wignore:Using or importing the ABCs:DeprecationWarning')
+    '-Wignore:Using or importing the ABCs:DeprecationWarning',
+
+    # Shows up in several places from importing PyTables
+    '-Wignore:`np.object` is a deprecated alias for the builtin `object`',
+    )
 
 
 class TestError(Exception):

--- a/testr/runner.py
+++ b/testr/runner.py
@@ -25,6 +25,24 @@ PYTEST_IGNORE_WARNINGS = (
 
     # Shows up in several places from importing PyTables
     '-Wignore:`np.object` is a deprecated alias for the builtin `object`',
+
+    # This warning comes about when running with the latest version MarksupSafe (>=2.0) but an old version of Jinja2<3.0.
+    "-Wignore: 'soft_unicode' has been renamed to 'soft_str'",
+
+    # acis_thermal_check/utils.py:164
+    # acis_thermal_check/utils.py:269
+    # acis_thermal_check/utils.py:290
+    # acis_thermal_check/utils.py:272
+    # Ska/Matplotlib/core.py:145
+    "-Wignore: linestyle is redundantly defined by the 'linestyle' keyword",
+
+    # annie/telem.py:18
+    #  (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
+    "-Wignore:  Creating an ndarray from ragged nested sequences",
+
+    # proseco/report_acq.py:477
+    # proseco/report_acq.py:480
+    "-Wignore: FixedFormatter should only be used together with FixedLocator",
     )
 
 


### PR DESCRIPTION
## Description

While preparing ska3-next (sot/skare3/pull/755) some warnings popped up. I added them here to discuss whether to ignore them or fix them before ska3-next. This change causes the warnings to be ignored.

- Since Numpy 1.20.0, numpy.object is deprecated. PyTable still uses it and this shows this warning:
   ```
   `np.object` is a deprecated alias for the builtin `object`
   ```
- conda-build requires jinja2 <3.0.0, and jinja2 2.* together with MarksupSafe lead to this warning:
   ```
   'soft_unicode' has been renamed to 'soft_str'
   ```
- a warning in annie I have not yet decided what to do with.

## Testing

- [n/a] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing: all run_testr tests pass if the proseco, acis_thermal_check, starcheck and Ska.Matplotlib PRs are merged.

Fixes #