### PR TITLE
Check internet connectivity by requesting web URL

### DIFF
--- a/testr/test_helper.py
+++ b/testr/test_helper.py
@@ -97,17 +97,20 @@ def is_32_bit():
     return sys.maxsize <= 2 ** 32
 
 
-def has_internet(host="8.8.8.8", port=53, timeout=3):
-    """Return True if internet is available by trying to reach ``host``.
+def has_internet(url='https://google.com', timeout=3):
+    """Return True if internet is available by trying to get ``url``.
 
-    Adapted from https://stackoverflow.com/questions/3764291
-    
+    Note that using sockets and https://stackoverflow.com/questions/3764291 has
+    problems:
+
+    - Using 8.8.8.8 and port 53 seems to not detect no internet access on Mac.
+    - Using socket.create_connection(('https://google.com', 443)) seems to
+      unexpectedly succeed on cheru.
+
     Parameters
     ----------
-    host : str
-        Host IP to reach (default=8.8.8.8 (google-public-dns-a.google.com))
-    port : int
-        Port to use (default=53)
+    url : str
+        URL to get (default=google.com)
     timeout : int, float
         Timeout in seconds (default=3)
 
@@ -115,10 +118,9 @@ def has_internet(host="8.8.8.8", port=53, timeout=3):
     -------
     has_internet : bool
     """
-    import socket
+    import urllib.request
     try:
-        socket.setdefaulttimeout(timeout)
-        socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect((host, port))
+        urllib.request.urlopen(url, timeout=timeout)
         return True
-    except socket.error:
+    except Exception:
         return False


### PR DESCRIPTION
## Description

This PR updates the `has_internet` test helper function to be more reliable. It now (by default) tries to fetch the page `google.com`.

### History

I discovered that the first go at this #38 gives a false positive "True" in the case when running on my Mac with the Wifi disconnected. Not clear what's going on but maybe some caching since the test IP address and port were the DNS server 8.8.8.8. 

Then I switched to using the higher-level interface `create_connection` in the `socket` module and to using host='google.com' and port=443 (https) for the default. But this then gave a false positive `True` when run on `cheru`.  Weird.

So finally just use `urllib.request` to get a web page. This is slow, about 300 ms, but is quite likely to be reliable in all cases.

## Testing

- [n/a] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing

### Functional testing

- With internet enabled on my Mac `has_internet()` returns `True`
- With internet disabled on my Mac `has_internet()` returns `False`
- Returns `False` on `cheru`.
- On Windows (VM on Mac):
  - Returns `False` with internet disabled, though for some insane reason the `timeout` is ignored and it takes about 10 seconds to return `False`.
  - Returns `True` with internet enabled.