### PR TITLE
Run pytest from TESTR_OUTPUT_DIR

### DIFF
--- a/testr/runner.py
+++ b/testr/runner.py
@@ -159,8 +159,8 @@ def test(*args, **kwargs):
                                     calling_frame_filename)
 
     pkg_dir = os.path.dirname(calling_func_file)
-
-    n_fail = pytest.main([pkg_dir] + list(args), **kwargs)
+    with chdir(os.environ.get('TESTR_OUT_DIR', '.')):
+        n_fail = pytest.main([pkg_dir] + list(args), **kwargs)
 
     if n_fail and raise_exception:
         raise TestError('got {} failure(s)'.format(n_fail))


### PR DESCRIPTION
## Description

This is a solution to the `hypothesis` problem (see `#aspect-team "falling back to an in-memory database for this session" hypothesis` ).

This would also generally solve the problem of tests that accidentally write stuff into package directories (with understanding that tests really should not do that).

## Interface impact

When running `ska_testr` or something like `import Chandra.Maneuver; Chandra.Maneuver.test()`, the path to the test file will be a long one, going from the current working directory up to root (with `../../  etc`) and then back down through the Python distribution files. See the functional testing example.

## Testing

- [n/a] No unit tests
- [x] Functional testing

### Functional test

This was tested in my existing `ska3-next` environment (2022.2rc6) so that I could hack it just slightly. In this case I created a directory `$CONDA_PREFIX/lib/python3.8/site-packages/.hypothesis` which is not writeable by anyone. This was to check if the fix worked since the offending `.hypothesis` directory gets deleted by pytest/hypothesis after tests complete. Using the unpatched (flight) version of `testr` I confirmed that this hack reproduced the problem we have seen on HEAD linux.

#### Testing from ska_testr
```
(ska3-next) ➜  ska_testr git:(master) export PYTHONPATH=$HOME/git/testr
(ska3-next) ➜  ska_testr git:(master) cd ~/git/ska_testr
(ska3-next) ➜  ska_testr git:(master) python -m testr.packages --include Chandra.Maneuver
****************************************
*** package Chandra.Maneuver         ***
****************************************

Copying input tests /Users/aldcroft/git/ska_testr/packages/Chandra.Maneuver to output dir /Users/aldcroft/git/ska_testr/outputs/logs/Darwin_2022-03-10T13-49-09_2022.2rc6-2aa4956_mprovost-l1.occ.harvard.edu/Chandra.Maneuver
Running python test_unit.py script
Bash-08:49:09> export TESTR_FILE='test_unit.py'
Bash-08:49:09> export TESTR_STATUS='not run'
Bash-08:49:09> export TESTR_INTERPRETER='python'
Bash-08:49:09> export TESTR_OUT_DIR='/Users/aldcroft/git/ska_testr/outputs/logs/Darwin_2022-03-10T13-49-09_2022.2rc6-2aa4956_mprovost-l1.occ.harvard.edu/Chandra.Maneuver'
Bash-08:49:09> export TESTR_REGRESS_DIR='/Users/aldcroft/git/ska_testr/outputs/regress/Darwin_2022-03-10T13-49-09_2022.2rc6-2aa4956_mprovost-l1.occ.harvard.edu/Chandra.Maneuver'
Bash-08:49:09> export TESTR_PACKAGES_REPO='https://github.com/sot'
Bash-08:49:09> export TESTR_PACKAGE='Chandra.Maneuver'
Bash-08:49:09> export TESTR_PACKAGE_VERSION='3.8.0'
Bash-08:49:09> python test_unit.py
HO

 /Users/aldcroft/git/ska_testr/outputs/logs/Darwin_2022-03-10T13-49-09_2022.2rc6-2aa4956_mprovost-l1.occ.harvard.edu/Chandra.Maneuver 


============================= test session starts ==============================
platform darwin -- Python 3.8.12, pytest-6.2.5, py-1.10.0, pluggy-1.0.0 -- /Users/aldcroft/miniconda3/envs/ska3-next/bin/python
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Users/aldcroft/git/ska_testr/outputs/logs/Darwin_2022-03-10T13-49-09_2022.2rc6-2aa4956_mprovost-l1.occ.harvard.edu/Chandra.Maneuver/.hypothesis/examples')
rootdir: /Users/aldcroft
plugins: remotedata-0.3.3, doctestplus-0.11.2, arraydiff-0.3, anyio-2.2.0, hypothesis-6.29.3, mock-3.6.1, filter-subpackage-0.1.1, openfiles-0.5.0, astropy-header-0.1.2, cov-3.0.0
collected 4 items                                                              

../../../../../../miniconda3/envs/ska3-next/lib/python3.8/site-packages/Chandra/Maneuver/tests/test_maneuver.py::test_attitudes PASSED
../../../../../../miniconda3/envs/ska3-next/lib/python3.8/site-packages/Chandra/Maneuver/tests/test_maneuver.py::test_versus_telemetry PASSED
../../../../../../miniconda3/envs/ska3-next/lib/python3.8/site-packages/Chandra/Maneuver/tests/test_maneuver.py::test_inject_errors PASSED
../../../../../../miniconda3/envs/ska3-next/lib/python3.8/site-packages/Chandra/Maneuver/tests/test_maneuver.py::test_inject_array_errors PASSED

- generated xml file: /Users/aldcroft/git/ska_testr/outputs/logs/Darwin_2022-03-10T13-49-09_2022.2rc6-2aa4956_mprovost-l1.occ.harvard.edu/Chandra.Maneuver/test_unit.py.xml -
============================== 4 passed in 0.89s ===============================
Bash-08:49:11> 
Running python post_check_logs.py script
Bash-08:49:11> export TESTR_FILE='post_check_logs.py'
Bash-08:49:11> export TESTR_STATUS='not run'
Bash-08:49:11> export TESTR_INTERPRETER='python'
Bash-08:49:11> export TESTR_OUT_DIR='/Users/aldcroft/git/ska_testr/outputs/logs/Darwin_2022-03-10T13-49-09_2022.2rc6-2aa4956_mprovost-l1.occ.harvard.edu/Chandra.Maneuver'
Bash-08:49:11> export TESTR_REGRESS_DIR='/Users/aldcroft/git/ska_testr/outputs/regress/Darwin_2022-03-10T13-49-09_2022.2rc6-2aa4956_mprovost-l1.occ.harvard.edu/Chandra.Maneuver'
Bash-08:49:11> export TESTR_PACKAGES_REPO='https://github.com/sot'
Bash-08:49:11> export TESTR_PACKAGE='Chandra.Maneuver'
Bash-08:49:11> export TESTR_PACKAGE_VERSION='3.8.0'
Bash-08:49:11> python post_check_logs.py
Bash-08:49:12> 
****************************************
*** Chandra.Maneuver Test Summary    ***
*** test_unit.py         pass        ***
*** post_check_logs.py   pass        ***
****************************************
...
```
#### Testing from the imported package 
```
(ska3-next) ➜  testr git:(test-from-current-dir) cd ~
(ska3-next) ➜  ~ ipython
Python 3.8.12 (default, Oct 12 2021, 06:23:56) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.29.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import Chandra.Maneuver

In [2]: Chandra.Maneuver.test('-v')
================================================================== test session starts ==================================================================
platform darwin -- Python 3.8.12, pytest-6.2.5, py-1.10.0, pluggy-1.0.0 -- /Users/aldcroft/miniconda3/envs/ska3-next/bin/python
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/Users/aldcroft/.hypothesis/examples')
rootdir: /Users/aldcroft
plugins: remotedata-0.3.3, doctestplus-0.11.2, arraydiff-0.3, anyio-2.2.0, hypothesis-6.29.3, mock-3.6.1, filter-subpackage-0.1.1, openfiles-0.5.0, astropy-header-0.1.2, cov-3.0.0
collected 4 items                                                                                                                                       

miniconda3/envs/ska3-next/lib/python3.8/site-packages/Chandra/Maneuver/tests/test_maneuver.py::test_attitudes PASSED                              [ 25%]
miniconda3/envs/ska3-next/lib/python3.8/site-packages/Chandra/Maneuver/tests/test_maneuver.py::test_versus_telemetry PASSED                       [ 50%]
miniconda3/envs/ska3-next/lib/python3.8/site-packages/Chandra/Maneuver/tests/test_maneuver.py::test_inject_errors PASSED                          [ 75%]
miniconda3/envs/ska3-next/lib/python3.8/site-packages/Chandra/Maneuver/tests/test_maneuver.py::test_inject_array_errors PASSED                    [100%]

=================================================================== 4 passed in 0.71s ===================================================================

```
#### Testing from git repo using `python setup.py test`
```
(ska3-next) ➜  ~ cd ~/git/Chandra.Maneuver
(ska3-next) ➜  Chandra.Maneuver git:(master) 
(ska3-next) ➜  Chandra.Maneuver git:(master) python setup.py test
running test
WARNING: Testing via this command is deprecated and will be removed in a future version. Users looking for a generic test entry point independent of test runner are encouraged to use tox.
running egg_info
writing Chandra.Maneuver.egg-info/PKG-INFO
writing dependency_links to Chandra.Maneuver.egg-info/dependency_links.txt
writing requirements to Chandra.Maneuver.egg-info/requires.txt
writing top-level names to Chandra.Maneuver.egg-info/top_level.txt
package init file 'Chandra/__init__.py' not found (or not a regular file)
adding license file 'LICENSE.rst'
writing manifest file 'Chandra.Maneuver.egg-info/SOURCES.txt'
running build_ext
================================================================== test session starts ==================================================================
platform darwin -- Python 3.8.12, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /Users/aldcroft/git/Chandra.Maneuver, configfile: pytest.ini
plugins: remotedata-0.3.3, doctestplus-0.11.2, arraydiff-0.3, anyio-2.2.0, hypothesis-6.29.3, mock-3.6.1, filter-subpackage-0.1.1, openfiles-0.5.0, astropy-header-0.1.2, cov-3.0.0
collected 4 items                                                                                                                                       

Chandra/Maneuver/tests/test_maneuver.py ....                                                                                                      [100%]

=================================================================== warnings summary ====================================================================
../../miniconda3/envs/ska3-next/lib/python3.8/site-packages/setuptools_scm/__init__.py:69
  /Users/aldcroft/miniconda3/envs/ska3-next/lib/python3.8/site-packages/setuptools_scm/__init__.py:69: DeprecationWarning: parse function setuptools_scm_git_archive.parse are required to provide a named argument 'config', setuptools_scm>=8.0 will remove support.
    version = _call_entrypoint_fn(root, config, ep.load())

-- Docs: https://docs.pytest.org/en/stable/warnings.html
============================================================= 4 passed, 1 warning in 0.92s ==============================================================
```