### PR TITLE
Disable hypothesis plugin autoload by default

### DIFF
--- a/testr/runner.py
+++ b/testr/runner.py
@@ -133,6 +133,14 @@ def test(*args, **kwargs):
     # flight directory if tests fail running on installed package.
     args = args + ('-p', 'no:cacheprovider')
 
+    if 'TESTR_ALLOW_HYPOTHESIS' not in os.environ:
+        # Disable autoload of hypothesis plugin which causes warnings due to
+        # trying to write to .hypothesis dir from the cwd of test runner. See
+        # slack #aspect-team "falling back to an in-memory database for this
+        # session" for more info.
+        args += ('-p', 'no:hypothesispytest')  # current name for disabling
+        args += ('-p', 'no:hypothesis')  # possible future name
+
     stack_level = kwargs.pop('stack_level', 1)
     calling_frame_record = inspect.stack()[stack_level]  # Only works for stack-based Python
     calling_func_file = calling_frame_record[1]


### PR DESCRIPTION
## Description

This PR addresses the problem of hypothesis trying to write into the current directory where tests are being run by disabling autoloading of the hypothesis plugin.

See also #40 for an alternate solution and a ref to the slack discussion.

## Testing

- [n/a] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing

### Functional testing

This was tested in my existing ska3-next environment (2022.2rc6) so that I could hack it just slightly. In this case I created a directory $CONDA_PREFIX/lib/python3.8/site-packages/.hypothesis which is not writeable by anyone. This was to check if the fix worked since the offending .hypothesis directory gets deleted by pytest/hypothesis after tests complete. Using the unpatched (flight) version of testr I confirmed that this hack reproduced the problem we have seen on HEAD linux.

#### With hypothesis disabled
```
(ska3-next) ➜  ska_testr git:(master) python -m testr.packages --include Chandra.Maneuver
****************************************
*** package Chandra.Maneuver         ***
****************************************

Copying input tests /Users/aldcroft/git/ska_testr/packages/Chandra.Maneuver to output dir /Users/aldcroft/git/ska_testr/outputs/logs/Darwin_2022-03-15T10-43-04_2022.2rc6-2aa4956_daze/Chandra.Maneuver
Running python test_unit.py script
Bash-06:43:04> export TESTR_FILE='test_unit.py'
Bash-06:43:04> export TESTR_STATUS='not run'
Bash-06:43:04> export TESTR_INTERPRETER='python'
Bash-06:43:04> export TESTR_OUT_DIR='/Users/aldcroft/git/ska_testr/outputs/logs/Darwin_2022-03-15T10-43-04_2022.2rc6-2aa4956_daze/Chandra.Maneuver'
Bash-06:43:04> export TESTR_REGRESS_DIR='/Users/aldcroft/git/ska_testr/outputs/regress/Darwin_2022-03-15T10-43-04_2022.2rc6-2aa4956_daze/Chandra.Maneuver'
Bash-06:43:04> export TESTR_PACKAGES_REPO='https://github.com/sot'
Bash-06:43:04> export TESTR_PACKAGE='Chandra.Maneuver'
Bash-06:43:04> export TESTR_PACKAGE_VERSION='3.8.0'
Bash-06:43:04> python test_unit.py
============================= test session starts ==============================
platform darwin -- Python 3.8.12, pytest-6.2.5, py-1.10.0, pluggy-1.0.0 -- /Users/aldcroft/miniconda3/envs/ska3-next/bin/python
rootdir: /Users/aldcroft/miniconda3/envs/ska3-next/lib/python3.8/site-packages
plugins: remotedata-0.3.3, doctestplus-0.11.2, arraydiff-0.3, anyio-2.2.0, mock-3.6.1, filter-subpackage-0.1.1, openfiles-0.5.0, astropy-header-0.1.2, cov-3.0.0
collected 4 items                                                              

Chandra/Maneuver/tests/test_maneuver.py::test_attitudes PASSED
Chandra/Maneuver/tests/test_maneuver.py::test_versus_telemetry PASSED
Chandra/Maneuver/tests/test_maneuver.py::test_inject_errors PASSED
Chandra/Maneuver/tests/test_maneuver.py::test_inject_array_errors PASSED

- generated xml file: /Users/aldcroft/git/ska_testr/outputs/logs/Darwin_2022-03-15T10-43-04_2022.2rc6-2aa4956_daze/Chandra.Maneuver/test_unit.py.xml -
============================== 4 passed in 1.84s ===============================
Bash-06:43:07> 
Running python post_check_logs.py script
Bash-06:43:07> export TESTR_FILE='post_check_logs.py'
Bash-06:43:07> export TESTR_STATUS='not run'
Bash-06:43:07> export TESTR_INTERPRETER='python'
Bash-06:43:07> export TESTR_OUT_DIR='/Users/aldcroft/git/ska_testr/outputs/logs/Darwin_2022-03-15T10-43-04_2022.2rc6-2aa4956_daze/Chandra.Maneuver'
Bash-06:43:07> export TESTR_REGRESS_DIR='/Users/aldcroft/git/ska_testr/outputs/regress/Darwin_2022-03-15T10-43-04_2022.2rc6-2aa4956_daze/Chandra.Maneuver'
Bash-06:43:07> export TESTR_PACKAGES_REPO='https://github.com/sot'
Bash-06:43:07> export TESTR_PACKAGE='Chandra.Maneuver'
Bash-06:43:07> export TESTR_PACKAGE_VERSION='3.8.0'
Bash-06:43:07> python post_check_logs.py
Bash-06:43:08> 
****************************************
*** Chandra.Maneuver Test Summary    ***
*** test_unit.py         pass        ***
*** post_check_logs.py   pass        ***
****************************************
```
#### With hypothesis enabled
```
(ska3-next) ➜  ska_testr git:(master) env TESTR_ALLOW_HYPOTHESIS=1 python -m testr.packages --include Chandra.Maneuver
****************************************
*** package Chandra.Maneuver         ***
****************************************

Copying input tests /Users/aldcroft/git/ska_testr/packages/Chandra.Maneuver to output dir /Users/aldcroft/git/ska_testr/outputs/logs/Darwin_2022-03-15T10-43-51_2022.2rc6-2aa4956_daze/Chandra.Maneuver
Running python test_unit.py script
Bash-06:43:51> export TESTR_FILE='test_unit.py'
Bash-06:43:51> export TESTR_STATUS='not run'
Bash-06:43:51> export TESTR_INTERPRETER='python'
Bash-06:43:51> export TESTR_OUT_DIR='/Users/aldcroft/git/ska_testr/outputs/logs/Darwin_2022-03-15T10-43-51_2022.2rc6-2aa4956_daze/Chandra.Maneuver'
Bash-06:43:51> export TESTR_REGRESS_DIR='/Users/aldcroft/git/ska_testr/outputs/regress/Darwin_2022-03-15T10-43-51_2022.2rc6-2aa4956_daze/Chandra.Maneuver'
Bash-06:43:51> export TESTR_PACKAGES_REPO='https://github.com/sot'
Bash-06:43:51> export TESTR_PACKAGE='Chandra.Maneuver'
Bash-06:43:51> export TESTR_PACKAGE_VERSION='3.8.0'
Bash-06:43:51> python test_unit.py
============================= test session starts ==============================
platform darwin -- Python 3.8.12, pytest-6.2.5, py-1.10.0, pluggy-1.0.0 -- /Users/aldcroft/miniconda3/envs/ska3-next/bin/python
/Users/aldcroft/miniconda3/envs/ska3-next/lib/python3.8/site-packages/hypothesis/database.py:60: HypothesisWarning: The database setting is not configured, and the default location is unusable - falling back to an in-memory database for this session.  path='/Users/aldcroft/miniconda3/envs/ska3-next/lib/python3.8/site-packages/.hypothesis/examples'
  warnings.warn(
hypothesis profile 'default' -> database=InMemoryExampleDatabase({})
rootdir: /Users/aldcroft/miniconda3/envs/ska3-next/lib/python3.8/site-packages
plugins: remotedata-0.3.3, doctestplus-0.11.2, arraydiff-0.3, anyio-2.2.0, hypothesis-6.29.3, mock-3.6.1, filter-subpackage-0.1.1, openfiles-0.5.0, astropy-header-0.1.2, cov-3.0.0
collected 4 items                                                              

Chandra/Maneuver/tests/test_maneuver.py::test_attitudes PASSED
Chandra/Maneuver/tests/test_maneuver.py::test_versus_telemetry PASSED
Chandra/Maneuver/tests/test_maneuver.py::test_inject_errors PASSED
Chandra/Maneuver/tests/test_maneuver.py::test_inject_array_errors PASSED

- generated xml file: /Users/aldcroft/git/ska_testr/outputs/logs/Darwin_2022-03-15T10-43-51_2022.2rc6-2aa4956_daze/Chandra.Maneuver/test_unit.py.xml -
============================== 4 passed in 0.95s ===============================
Bash-06:43:53> 
Running python post_check_logs.py script
Bash-06:43:53> export TESTR_FILE='post_check_logs.py'
Bash-06:43:53> export TESTR_STATUS='not run'
Bash-06:43:53> export TESTR_INTERPRETER='python'
Bash-06:43:53> export TESTR_OUT_DIR='/Users/aldcroft/git/ska_testr/outputs/logs/Darwin_2022-03-15T10-43-51_2022.2rc6-2aa4956_daze/Chandra.Maneuver'
Bash-06:43:53> export TESTR_REGRESS_DIR='/Users/aldcroft/git/ska_testr/outputs/regress/Darwin_2022-03-15T10-43-51_2022.2rc6-2aa4956_daze/Chandra.Maneuver'
Bash-06:43:53> export TESTR_PACKAGES_REPO='https://github.com/sot'
Bash-06:43:53> export TESTR_PACKAGE='Chandra.Maneuver'
Bash-06:43:53> export TESTR_PACKAGE_VERSION='3.8.0'
Bash-06:43:53> python post_check_logs.py
Traceback (most recent call last):
  File "post_check_logs.py", line 3, in <module>
    check_files('test_*.log', ['warning', 'error'],
  File "/Users/aldcroft/git/testr/testr/packages.py", line 644, in check_files
    raise ValueError('Found matches in check_files:\n{}'.format('\n'.join(matches)))
ValueError: Found matches in check_files:
'warning' matched at test_unit.log:11 :: /Users/aldcroft/miniconda3/envs/ska3-next/lib/python3.8/site-packages/hypothesis/database.py:60: HypothesisWarning: The database setting is not configured, and the default location is unusable - falling back to an in-memory database for this session.  path='/Users/aldcroft/miniconda3/envs/ska3-next/lib/python3.8/site-packages/.hypothesis/examples'
'warning' matched at test_unit.log:12 :: warnings.warn(
Bash-06:43:54> ****************************************
*** Chandra.Maneuver Test Summary    ***
*** test_unit.py         pass        ***
*** post_check_logs.py   FAIL        ***
****************************************
```


