### PR TITLE
Extirpate Ska.Shell

### DIFF
--- a/testr/packages.py
+++ b/testr/packages.py
@@ -318,8 +318,10 @@ def run_tests(package, tests):
 
             test['t_stop'] = datetime.datetime.now().strftime('%Y:%m:%dT%H:%M:%S')
 
-    box_output(['{} Test Summary'.format(package)] +
-               ['{:20s} {}'.format(test['file'], test['status']) for test in tests])
+    box_output(
+        ['{} Test Summary'.format(package)]
+        + ['{:20s} {}'.format(test['file'], test['status']) for test in tests]
+    )
 
 
 def get_results_table(tests):

--- a/testr/packages.py
+++ b/testr/packages.py
@@ -18,7 +18,6 @@ import yaml
 
 
 import Ska.File
-from Ska.Shell import bash, ShellError
 from pyyaks.logger import get_logger
 from astropy.table import Table
 from cxotime import CxoTime
@@ -94,6 +93,34 @@ class Tee(object):
 
     def fileno(self):
         return sys.stdout.fileno()
+
+
+def communicate(process, log):
+    """
+    Real-time reading of a subprocess stdout.
+    Parameters
+    ----------
+    process:
+        process returned by subprocess.Popen
+    log: a stream object
+    """
+    if process.stdout is None:
+        process.wait()
+        return
+
+    while True:
+        if process.poll() is not None:
+            break
+        line = process.stdout.readline()
+        line = line if process.text_mode else line.decode()
+        log.write(line)
+        log.flush()
+
+    # in case the buffer is still not empty after the process ended
+    for line in process.stdout.readlines():
+        line = line if process.text_mode else line.decode()
+        log.write(line)
+        log.flush()
 
 
 def box_output(lines, min_width=40):
@@ -259,10 +286,9 @@ def run_tests(package, tests):
             # no interpreter assume the file is executable.
             test['t_start'] = datetime.datetime.now().strftime('%Y:%m:%dT%H:%M:%S')
 
+            # Need full environment in the subprocess run
+            env.update(os.environ)
             if test_helper.is_windows():
-                # Need full environment in the subprocess run
-                env.update(os.environ)
-
                 cmds = [sys.executable, test['file']]
                 try:
                     sub = subprocess.run(cmds, env=env, capture_output=True)
@@ -273,21 +299,22 @@ def run_tests(package, tests):
                 else:
                     test['status'] = 'pass' if sub.returncode == 0 else 'FAIL'
             else:
-                if interpreter == 'bash':
-                    with open(test['file'], 'r') as fh:
-                        cmd = fh.read()
-                elif interpreter is None:
-                    cmd = './' + test['file']
+                if interpreter is None:
+                    cmd = [f"./{test['file']}"]
                 else:
-                    cmd = interpreter + ' ' + test['file']
+                    cmd = [interpreter, test['file']]
 
                 try:
-                    bash(cmd, logfile=logfile, env=env)
-                except ShellError:
-                    # Test process returned a non-zero status => Fail
+                    process = None
+                    process = subprocess.Popen(
+                        cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+                    )
+                    communicate(process, log=logfile)
+                except Exception:
                     test['status'] = 'FAIL'
                 else:
-                    test['status'] = 'pass'
+                    test_ok = (process is not None) and (process.returncode == 0)
+                    test['status'] = 'pass' if test_ok else 'FAIL'
 
             test['t_stop'] = datetime.datetime.now().strftime('%Y:%m:%dT%H:%M:%S')
 

--- a/testr/runner.py
+++ b/testr/runner.py
@@ -26,13 +26,16 @@ PYTEST_IGNORE_WARNINGS = (
     # Shows up in several places from importing PyTables
     '-Wignore:`np.object` is a deprecated alias for the builtin `object`',
 
-    # This warning comes about when running with the latest version MarksupSafe (>=2.0) but an old version of Jinja2<3.0.
+    # This warning comes about when running with the latest version MarksupSafe (>=2.0) but an old
+    # version of Jinja2<3.0.
     "-Wignore: 'soft_unicode' has been renamed to 'soft_str'",
 
     # annie/telem.py:18
-    #  (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
+    #  (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes)
+    # is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the
+    # ndarray.
     "-Wignore:  Creating an ndarray from ragged nested sequences",
-    )
+)
 
 
 class TestError(Exception):


### PR DESCRIPTION
## Description

This is a proposal to remove the use of Ska.Shell from testr. This PR replaces it with `subprocess`.

What bugs me the most about Ska.Shell is that I have not been able to stop it from polluting my history. Because I run testr on my account, my bash history looks like this:
```
  484  ln -s /export/jgonzale/github-workflows/miniconda3/envs/ska3-masters/data/mica/archive/vv/15/15175_v03/slot_7_z.png /tmp/tmpbg7sz1hw/15/15175
  485  echo $?
  486  ln -s /export/jgonzale/github-workflows/miniconda3/envs/ska3-masters/data/mica/archive/vv/15/15175_v03/slot_7_m.png /tmp/tmpbg7sz1hw/15/15175
  487  echo $?
  488  export TESTR_FILE='test_regress_head.sh'
  489  export TESTR_STATUS='not run'
  490  export TESTR_INTERPRETER='bash'
  491  export TESTR_OUT_DIR='/export/jgonzale/ska_testr/test_outputs/logs/Linux_2022-04-06T03-01-08_8073a51_kady.cfa.harvard.edu/psmc_check'
  492  export TESTR_REGRESS_DIR='/export/jgonzale/ska_testr/test_outputs/regress/Linux_2022-04-06T03-01-08_8073a51_kady.cfa.harvard.edu/psmc_check'
  493  export TESTR_PACKAGES_REPO='https://github.com/sot'
  494  export TESTR_PACKAGE='psmc_check'
  495  export TESTR_PACKAGE_VERSION='unknown'
  496  export ALLOW_NONSTANDARD_OFLSDIR=1
  497  echo $?
  498  echo $?
```


## Interface impacts

There are no API impacts, but this PR impacts the user interface because the pytest output is not in color anymore. Pytest writes colorful output if it detects it's running on a shell. One can still force by adding the `--color=yes` option.

## Testing

### Unit tests

- [x] No unit tests


Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests

So far I tested that kadi tests pass, but a few more tests might be needed.
