### PR TITLE
Add duplicate_package_info function

### DIFF
--- a/testr/setup_helper.py
+++ b/testr/setup_helper.py
@@ -5,6 +5,7 @@ that ``python setup.py test`` runs tests via pytest.
 """
 
 import sys
+
 from setuptools.command.test import test as TestCommand
 
 __all__ = ['cmdclass', 'PyTest']
@@ -23,8 +24,10 @@ class PyTest(TestCommand):
 
     def run_tests(self):
         # Import here because outside the eggs aren't loaded
-        import pytest
         import shlex
+
+        import pytest
+
         from .runner import PYTEST_IGNORE_WARNINGS
 
         args = list(PYTEST_IGNORE_WARNINGS)
@@ -36,3 +39,26 @@ class PyTest(TestCommand):
 
 # setup() cmdclass keyword for testing with py.test
 cmdclass = {'test': PyTest}
+
+
+def duplicate_package_info(vals, name_in, name_out):
+    """
+    Duplicate a list or dict of values inplace, replacing ``name_in`` with ``name_out``.
+
+    Normally used in setup.py for making a namespace package that copies a flat one.
+    For an example see setup.py in the ska_sun or Ska.Sun repo.
+
+    :param vals: list or dict of values
+    :param name_in: string to replace at start of each value
+    :param name_out: output string
+    """
+    import re
+
+    for name in list(vals):
+        new_name = re.sub(f"^{name_in}", name_out, name)
+        if isinstance(vals, dict):
+            vals[new_name] = vals[name]
+        else:
+            vals.append(new_name)
+
+


### PR DESCRIPTION
## Description

Provide a new helper function for use in `setup.py` to facilitate flattening namespace packages, e.g. https://github.com/sot/Ska.Sun/pull/22.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Adds a function.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Used in https://github.com/sot/Ska.Sun/pull/22 to generate a working package. It seems to work.
