### PR TITLE
Remove PYTEST_IGNORE_WARNINGS from runner and use pytest.ini instead

### DIFF
--- a/testr/packages.py
+++ b/testr/packages.py
@@ -182,16 +182,23 @@ def collect_tests():
                 else:
                     interpreter = None
 
-                test = {'file': test_file,
-                        'status': status,
-                        'interpreter': interpreter,
-                        'out_dir': out_dir,
-                        'regress_dir': regress_dir,
-                        'packages_repo': opt.packages_repo,
-                        'package': package,
-                        'package_version': version,
-                        'coverage': opt.coverage,
-                        'coverage_config': opt.coverage_config}
+                test = {
+                    'file': test_file,
+                    'status': status,
+                    'interpreter': interpreter,
+                    'out_dir': out_dir,
+                    'regress_dir': regress_dir,
+                    'packages_repo': opt.packages_repo,
+                    'package': package,
+                    'package_version': version,
+                    'coverage': opt.coverage,
+                    'coverage_config': opt.coverage_config,
+                    'pytest_ini': opt.root / 'pytest.ini'
+                }
+
+                pkg_pytest_ini = in_dir / 'pytest.ini'
+                if test_file.endswith('.py') and pkg_pytest_ini.exists():
+                    test['pkg_pytest_ini'] = str(pkg_pytest_ini)
 
                 tests[package].append(test)
 

--- a/testr/packages.py
+++ b/testr/packages.py
@@ -199,7 +199,8 @@ def collect_tests():
                     pytest_ini = in_dir / 'pytest.ini'
                     if not pytest_ini.exists():
                         pytest_ini = opt.root / 'pytest.ini'
-                    test['pytest_ini'] = pytest_ini
+                    if pytest_ini.exists():
+                        test['pytest_ini'] = pytest_ini
 
                 tests[package].append(test)
 

--- a/testr/packages.py
+++ b/testr/packages.py
@@ -193,12 +193,13 @@ def collect_tests():
                     'package_version': version,
                     'coverage': opt.coverage,
                     'coverage_config': opt.coverage_config,
-                    'pytest_ini': opt.root / 'pytest.ini'
                 }
 
-                pkg_pytest_ini = in_dir / 'pytest.ini'
-                if test_file.endswith('.py') and pkg_pytest_ini.exists():
-                    test['pkg_pytest_ini'] = str(pkg_pytest_ini)
+                if test_file.endswith('.py'):
+                    pytest_ini = in_dir / 'pytest.ini'
+                    if not pytest_ini.exists():
+                        pytest_ini = opt.root / 'pytest.ini'
+                    test['pytest_ini'] = pytest_ini
 
                 tests[package].append(test)
 

--- a/testr/runner.py
+++ b/testr/runner.py
@@ -112,11 +112,14 @@ def test(*args, **kwargs):
     # flight directory if tests fail running on installed package.
     args = args + ('-p', 'no:cacheprovider')
 
-    if 'TESTR_PKG_PYTEST_INI' in os.environ:
-        args += ('-c', os.environ['TESTR_PKG_PYTEST_INI'])
-    else:
-        args += ('-c', os.environ['TESTR_PYTEST_INI'])
-
+    pytest_ini = os.environ.get('TESTR_PYTEST_INI', None)
+    if pytest_ini is not None:
+        if os.path.exists(pytest_ini):
+            args += ('-c', os.path.abspath(pytest_ini))
+        else:
+            raise Exception(
+                f'Pytest config file does not exist (TESTR_PYTEST_INI={pytest_ini})'
+            )
 
     if 'TESTR_ALLOW_HYPOTHESIS' not in os.environ:
         # Disable autoload of hypothesis plugin which causes warnings due to

--- a/testr/runner.py
+++ b/testr/runner.py
@@ -7,37 +7,6 @@ Provide a test() function that can be called from package __init__.
 import os
 
 
-# Pytest args for main() to ignore several warnings that show up regularly in
-# testing but can be ignored.
-PYTEST_IGNORE_WARNINGS = (
-    # See https://github.com/numpy/numpy/issues/11788 for why the numpy.ufunc
-    # warning is apparently OK.
-    '-Wignore:numpy.ufunc size changed:RuntimeWarning',
-
-    # Shows up in upstream packages including ipyparallel
-    '-Wignore:the imp module is deprecated in favour of importlib:DeprecationWarning',
-
-    # Shows up in setuptools_scm
-    '-Wignore:parse functions are required to provide a named:PendingDeprecationWarning',
-
-    # Shows up in sparkles from importing bleach
-    '-Wignore:Using or importing the ABCs:DeprecationWarning',
-
-    # Shows up in several places from importing PyTables
-    '-Wignore:`np.object` is a deprecated alias for the builtin `object`',
-
-    # This warning comes about when running with the latest version MarksupSafe (>=2.0) but an old
-    # version of Jinja2<3.0.
-    "-Wignore: 'soft_unicode' has been renamed to 'soft_str'",
-
-    # annie/telem.py:18
-    #  (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes)
-    # is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the
-    # ndarray.
-    "-Wignore:  Creating an ndarray from ragged nested sequences",
-)
-
-
 class TestError(Exception):
     pass
 
@@ -134,8 +103,6 @@ def test(*args, **kwargs):
     if kwargs.pop('show_output', False) and '-s' not in args and '--capture' not in arg_names:
         args = args + ('-s',)
 
-    args = args + PYTEST_IGNORE_WARNINGS
-
     if 'TESTR_OUT_DIR' in os.environ and 'TESTR_FILE' in os.environ:
         report_file = os.path.join(os.environ['TESTR_OUT_DIR'], f"{os.environ['TESTR_FILE']}.xml")
         args += (f'--junit-xml={report_file}',)
@@ -144,6 +111,12 @@ def test(*args, **kwargs):
     # Disable caching of test results to prevent users trying to write into
     # flight directory if tests fail running on installed package.
     args = args + ('-p', 'no:cacheprovider')
+
+    if 'TESTR_PKG_PYTEST_INI' in os.environ:
+        args += ('-c', os.environ['TESTR_PKG_PYTEST_INI'])
+    else:
+        args += ('-c', os.environ['TESTR_PYTEST_INI'])
+
 
     if 'TESTR_ALLOW_HYPOTHESIS' not in os.environ:
         # Disable autoload of hypothesis plugin which causes warnings due to


### PR DESCRIPTION
## Description

This PR removes some hardcoded pytest flags from `testr/runner.py`. In principle, we could remove other hardcoded options.

It replaces it by a `pytest.ini` file that must be placed in the `ska_testr` directory.

Optionally, one can add a `pytest.ini` file to the `ska_testr/packages/whatever` and this one will take precedence over the one at the top. This is to be used in some packages that require other pytest options.

If you have a setup like mine, where I have a `git` directory with many local git repositories within, you can also use this `pytest.ini` by making a soft link to it in your `git` directory. Pytest will go up the paths until it finds the first pytest.ini, which in most cases will be this one. This might not work always, but it might work in all our cases.

## Interface impacts
Requires a `pytest.ini` in ska_testr

## Testing


### Unit tests

- [x] No unit tests

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

All these tests are on `2023.1rc4`.

- Run `run_testr --include Chandra.Maneuver`, which gives several warnings.

- Create a `ska_testr/pytest.ini` file with the following contents:
   ```
   [pytest]
   filterwarnings =
       ignore:the imp module
       ignore:`np.object` is a deprecated alias for the builtin
       ignore:'soft_unicode' has been renamed to 'soft_str'
       ignore:Jupyter is migrating its paths
       ignore:Importing clear_output from IPython.core.display is deprecated
       ignore:Importing display from IPython.core.display is deprecated
       ignore:distutils Version classes are deprecated
   log_cli = False
   log_cli_level = DEBUG
   ```
   and `run_testr --include Chandra.Maneuver`, which shows no warnings.
- Create a `packages/Chandra.Maneuver/pytest.ini` file with these contents:
   ```
   [pytest]
   filterwarnings =
       ignore:\n\n  `numpy.distutils` is deprecated:DeprecationWarning
   ```
   and run `run_testr --include Chandra.Maneuver`, which shows all the warnings except the numpy.distutils deprecation warning. This is as expected, with the package ini file taking precedence over the top-level file.
- Ran pytest on `Ska.ftp` local repo with no warnings:
   ```
   cd /proj/sot/ska/jgonzalez/git
   cd ska_testr
   git fetch
   git co pytest-ini
   cd ..
   ln -s ska_testr/pytest.ini .
   cd Ska.ftp
   pytest ska_ftp
   ```
