### PR TITLE
remove PYTEST_IGNORE_WARNINGS from setup_helper

### DIFF
--- a/testr/setup_helper.py
+++ b/testr/setup_helper.py
@@ -25,9 +25,8 @@ class PyTest(TestCommand):
         # Import here because outside the eggs aren't loaded
         import pytest
         import shlex
-        from .runner import PYTEST_IGNORE_WARNINGS
 
-        args = list(PYTEST_IGNORE_WARNINGS)
+        args = []
         if self.args:
             args += shlex.split(self.args)
         errno = pytest.main(args)


### PR DESCRIPTION
## Description

Remove remaining use of PYTEST_IGNORE_WARNINGS.

Fixes #48

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests


### Functional tests

I ran the following on the Quaternion local repo, using this PR on top of a 2023.1rc7 environment:
```
python setup.py test
```
