### PR TITLE
Add handling for missing isatty attr on stdout

### DIFF
--- a/testr/runner.py
+++ b/testr/runner.py
@@ -7,6 +7,24 @@ Provide a test() function that can be called from package __init__.
 import os
 
 
+# Make a class to wrap sys.stdout to handle requests for isatty.  This is needed
+# to get the right output from pytest when run from FOT MATLAB pyexec.
+# Borrowed from https://github.com/pytest-dev/pytest/issues/5462
+class StdOutWrapper:
+
+    def __init__(self, stdout):
+        self._stdout = stdout
+
+    def __getattr__(self, item):
+        if item == "isatty":
+            return self.isatty
+        else:
+            return getattr(self._stdout, item)
+
+    def isatty(self):
+        return False
+
+
 class TestError(Exception):
     pass
 
@@ -64,6 +82,9 @@ def test(*args, **kwargs):
     import inspect
     import pytest
     import contextlib
+
+    # Use the StdOutWrapper to make sure that isatty returns something for sys.stdout
+    sys.stdout = StdOutWrapper(sys.stdout)
 
     # Copied from Ska.File to reduce import footprint and limit to only standard
     # modules.

--- a/testr/runner.py
+++ b/testr/runner.py
@@ -16,10 +16,7 @@ class StdOutWrapper:
         self._stdout = stdout
 
     def __getattr__(self, item):
-        if item == "isatty":
-            return self.isatty
-        else:
-            return getattr(self._stdout, item)
+        return getattr(self._stdout, item)
 
     def isatty(self):
         return False


### PR DESCRIPTION
## Description

Add handling for missing isatty attr on stdout.  This should fix 

```
"C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\_pytest\terminal.py", line 340, in __init__
PYPROC(stderr): INTERNALERROR>     self.isatty = file.isatty()
PYPROC(stderr): INTERNALERROR> AttributeError: module 'redirect_stdout' has no attribute 'isatty'
```

when trying to run testr tests from fot matlab pyexec.


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

As a regression test -- on fido/linux from a personal ska3 masters conda environment I ran all ska_testr tests with and without this change in my PYTHONPATH and all tests appeared to correctly run and were pass.

From the current testing branch of Matlab I also ran the Quaternion tests successfully using this testr branch (most other packages fail for other reasons):
```
>> pyexec('import sys')
PYEXEC: Using custom python program name: C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\python.exe
        and python home: C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing
>> pyexec('sys.path.insert(0, "C:\\Users\\unksm\\git\\testr")')
>> pyexec('import testr')
PYPROC(stderr): Traceback (most recent call last):
PYPROC(stderr):   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\ska_helpers\version.py", line 114, in get_version
PYPROC(stderr):     assert ok
PYPROC(stderr): AssertionError
PYPROC(stderr): 
PYPROC(stderr): During handling of the above exception, another exception occurred:
PYPROC(stderr): 
PYPROC(stderr): Traceback (most recent call last):
PYPROC(stderr):   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\ska_helpers\version.py", line 148, in get_version
PYPROC(stderr):     version = get_version(root=Path(*roots), relative_to=module_file)
PYPROC(stderr):   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\setuptools_scm\__init__.py", line 146, in get_version
PYPROC(stderr):     maybe_version = _get_version(config)
PYPROC(stderr):   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\setuptools_scm\__init__.py", line 153, in _get_version
PYPROC(stderr):     parsed_version = _do_parse(config)
PYPROC(stderr):   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\setuptools_scm\__init__.py", line 100, in _do_parse
PYPROC(stderr):     version = _version_from_entrypoints(config) or _version_from_entrypoints(
PYPROC(stderr):   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\setuptools_scm\_entrypoints.py", line 66, in _version_from_entrypoints
PYPROC(stderr):     version: ScmVersion | None = _call_entrypoint_fn(root, config, ep.load())
PYPROC(stderr):   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\setuptools_scm\_entrypoints.py", line 40, in _call_entrypoint_fn
PYPROC(stderr):     return fn(root, config=config)
PYPROC(stderr):   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\setuptools_scm\git.py", line 179, in parse
PYPROC(stderr):     wd = get_working_directory(config)
PYPROC(stderr):   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\setuptools_scm\git.py", line 159, in get_working_directory
PYPROC(stderr):     return GitWorkdir.from_potential_worktree(config.parent)
PYPROC(stderr):   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\setuptools_scm\git.py", line 54, in from_potential_worktree
PYPROC(stderr):     require_command(cls.COMMAND)
PYPROC(stderr):   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\setuptools_scm\utils.py", line 171, in require_command
PYPROC(stderr):     raise OSError("%r was not found" % name)
PYPROC(stderr): OSError: 'git' was not found
PYPROC(stderr): 
PYPROC(stderr): 
PYPROC(stderr): 
PYPROC(stderr): Failed to find a package version, setting to 0.0.0
PYPROC(stderr): ********************************************************************************
PYPROC(stderr): Getting version for package=testr distribution=None 
PYPROC(stderr):   Current directory: C:\Users\unksm
PYPROC(stderr):   sys.path=['C:\\Users\\unksm\\git\\testr', 'C:\\Users\\unksm\\Documents\\MATLAB\\FOT_Tools\\Python\\python3_Windows_64bit_testing\\python310.zip', 'C:\\Users\\unksm\\Documents\\MATLAB\\FOT_Tools\\Python\\python3_Windows_64bit_testing\\DLLs', 'C:\\Users\\unksm\\Documents\\MATLAB\\FOT_Tools\\Python\\python3_Windows_64bit_testing\\lib', 'C:\\Users\\unksm\\Documents\\MATLAB\\FOT_Tools\\Python\\python3_interface_testing\\private', 'C:\\Users\\unksm\\Documents\\MATLAB\\FOT_Tools\\Python\\python3_Windows_64bit_testing', 'C:\\Users\\unksm\\Documents\\MATLAB\\FOT_Tools\\Python\\python3_Windows_64bit_testing\\lib\\site-packages', 'C:\\Users\\unksm\\Documents\\MATLAB\\FOT_Tools\\Python\\python3_Windows_64bit_testing\\lib\\site-packages\\win32', 'C:\\Users\\unksm\\Documents\\MATLAB\\FOT_Tools\\Python\\python3_Windows_64bit_testing\\lib\\site-packages\\win32\\lib', 'C:\\Users\\unksm\\Documents\\MATLAB\\FOT_Tools\\Python\\python3_Windows_64bit_testing\\lib\\site-packages\\Pythonwin']
PYPROC(stderr):   module_file='C:\\Users\\unksm\\git\\testr\\testr\\__init__.py'
PYPROC(stderr):   Getting distribution dist_info=get_distribution(testr)
PYPROC(stderr):     dist_info.location='c:\\users\\unksm\\documents\\matlab\\fot_tools\\python\\python3_windows_64bit_testing\\lib\\site-packages'
PYPROC(stderr):     dist_info.version='4.11.3'
PYPROC(stderr):     WARNING: distinfo.location does not match module_file, falling through to setuptools_scm
PYPROC(stderr):   Getting version via setuptools_scm for git repo
PYPROC(stderr):     Running get_version(
PYPROC(stderr):         root=..,
PYPROC(stderr):         relative_to=C:\Users\unksm\git\testr\testr\__init__.py
PYPROC(stderr):     )
PYPROC(stderr): WARNING: got version='0.0.0'
PYPROC(stderr): ********************************************************************************
PYPROC(stderr): 
>> pyexec('print(testr.__file__)')
PYPROC: C:\Users\unksm\git\testr\testr\__init__.py
>> pyexec('import Quaternion')
>> pyexec('Quaternion.test()')
PYPROC: ============================= test session starts =============================
PYPROC: platform win32 -- Python 3.10.8, pytest-7.2.0, pluggy-1.0.0
PYPROC: rootdir: C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages
PYPROC: plugins: anyio-3.6.2, timeout-2.1.0
PYPROC: collected 66 items
PYPROC: 
PYPROC: Quaternion\tests\test_all.py ..PYPROC: ....PYPROC: .....PYPROC: ....PYPROC: ....PYPROC: .PYPROC: .....PYPROC: ..PYPROC: ..PYPROC: ..PYPROC: .PYPROC: .PYPROC: ..PYPROC: ....PYPROC: .    [ 60%]
PYPROC: Quaternion\tests\test_shaped.py ...PYPROC: ...PYPROC: ....PYPROC: ...PYPROC: ...PYPROC: ....PYPROC: ...PYPROC: ...               [100%]PYPROC: 
PYPROC: 
PYPROC: ============================= 66 passed in 3.40s ==============================
```
This compares with not using this patch in testr
```
>> pyexec('import Quaternion')
PYEXEC: Using custom python program name: C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\python.exe
        and python home: C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing
>> pyexec('Quaternion.test()')
PYPROC(stderr): INTERNALERROR> Traceback (most recent call last):
PYPROC(stderr): INTERNALERROR>   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\_pytest\main.py", line 266, in wrap_session
PYPROC(stderr): INTERNALERROR>     config._do_configure()
PYPROC(stderr): INTERNALERROR>   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\_pytest\config\__init__.py", line 1037, in _do_configure
PYPROC(stderr): INTERNALERROR>     self.hook.pytest_configure.call_historic(kwargs=dict(config=self))
PYPROC(stderr): INTERNALERROR>   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\pluggy\_hooks.py", line 277, in call_historic
PYPROC(stderr): INTERNALERROR>     res = self._hookexec(self.name, self.get_hookimpls(), kwargs, False)
PYPROC(stderr): INTERNALERROR>   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\pluggy\_manager.py", line 80, in _hookexec
PYPROC(stderr): INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
PYPROC(stderr): INTERNALERROR>   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\pluggy\_callers.py", line 60, in _multicall
PYPROC(stderr): INTERNALERROR>     return outcome.get_result()
PYPROC(stderr): INTERNALERROR>   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\pluggy\_result.py", line 60, in get_result
PYPROC(stderr): INTERNALERROR>     raise ex[1].with_traceback(ex[2])
PYPROC(stderr): INTERNALERROR>   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\pluggy\_callers.py", line 39, in _multicall
PYPROC(stderr): INTERNALERROR>     res = hook_impl.function(*args)
PYPROC(stderr): INTERNALERROR>   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\_pytest\terminal.py", line 238, in pytest_configure
PYPROC(stderr): INTERNALERROR>     reporter = TerminalReporter(config, sys.stdout)
PYPROC(stderr): INTERNALERROR>   File "C:\Users\unksm\Documents\MATLAB\FOT_Tools\Python\python3_Windows_64bit_testing\lib\site-packages\_pytest\terminal.py", line 340, in __init__
PYPROC(stderr): INTERNALERROR>     self.isatty = file.isatty()
PYPROC(stderr): INTERNALERROR> AttributeError: module 'redirect_stdout' has no attribute 'isatty'
```