### PR TITLE
Handle StdOutWrapper class with context manager

### DIFF
--- a/testr/runner.py
+++ b/testr/runner.py
@@ -45,7 +45,7 @@ def testr(*args, **kwargs):
         kwargs.setdefault(kwarg, True)
 
     # test() function looks up the calling stack to find the calling package name.
-    # It will be three levels up including the stdout_wrapper test_wrapper function.
+    # It will be two levels up.
     kwargs['stack_level'] = 2
 
     return test(*args, **kwargs)

--- a/testr/runner.py
+++ b/testr/runner.py
@@ -24,6 +24,7 @@ class StdOutWrapper:
 
 def stdout_wrapper(func):
     import sys
+
     def test_wrapper(*args, **kwargs):
         orig_stdout = sys.stdout
         sys.stdout = StdOutWrapper(sys.stdout)
@@ -32,6 +33,7 @@ def stdout_wrapper(func):
         finally:
             sys.stdout = orig_stdout
     return test_wrapper
+
 
 class TestError(Exception):
     pass


### PR DESCRIPTION
## Description

Handle StdOutWrapper class with context manager

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
I wasn't thrilled to have the testr running code leave the sys.stdout changed in any way due to #50 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests

Ran all ska_testr tests on linux with this in PYTHONPATH

<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Also ran from Windows Matlab pyexec, with before
```
>> pyexec('sys.path.insert(0, "C:\\Users\\unksm\\git\\testr")')
>> pyexec('print(sys.stdout)')
PYPROC: <module 'redirect_stdout'>
>> pyexec('import Quaternion; Quaternion.test(); print(sys.stdout)')
...
PYPROC: ============================= 66 passed in 1.69s ==============================
PYPROC: <testr.runner.StdOutWrapper object at 0x00000269982EB130>
```
and with this PR
```
PYPROC: ============================= 66 passed in 1.58s ==============================
PYPROC: <module 'redirect_stdout'>
```

