### PR TITLE
Explicitly set pytest rootdir option for running tests

### DIFF
--- a/testr/runner.py
+++ b/testr/runner.py
@@ -185,7 +185,17 @@ def test(*args, **kwargs):
     pkg_paths = [os.path.dirname(calling_func_file)] + ['..'] * len(pkg_names)
     pkg_dir = os.path.join(*pkg_names)
 
-    with chdir(os.path.join(*pkg_paths)):
+    # Set the rootdir to the top of the package directory. This gets used in two ways:
+    # 1. To set the working directory for the test run.
+    # 2. To set the default for the --rootdir option in the pytest call.
+    #
+    # For part 2, see https://github.com/sot/skare3/issues/1294 for context, but in
+    # summary pytest > 8.0.0 uses the location of a pytest.ini file to set the rootdir
+    # unless it is explicitly specified. This is generally NOT what we want.
+    rootdir = os.path.abspath(os.path.join(*pkg_paths))
+    kwargs.setdefault('rootdir', rootdir)
+
+    with chdir(rootdir):
         if with_coverage:
             coverage_file = os.path.join(
                 os.environ['TESTR_OUT_DIR'],

--- a/testr/runner.py
+++ b/testr/runner.py
@@ -68,7 +68,9 @@ def test(*args, **kwargs):
     :param package_from_dir: set package name from parent directory name (default=False)
     :param verbose: run pytest in verbose (-v) mode (default=False)
     :param show_output: run pytest in show output (-s) mode (default=False)
-    :param \*\*kwargs: additional keyword args to pass to pytest
+    :param \*\*kwargs: additional command line options to pass to pytest, where the
+        key is the option name (e.g. "--log-level") and the value is the option value.
+        This is passed to the pytest CLI as the string ``{key}={value}``.
 
     :returns: number of test failures
     """
@@ -193,7 +195,8 @@ def test(*args, **kwargs):
     # summary pytest > 8.0.0 uses the location of a pytest.ini file to set the rootdir
     # unless it is explicitly specified. This is generally NOT what we want.
     rootdir = os.path.abspath(os.path.join(*pkg_paths))
-    kwargs.setdefault('rootdir', rootdir)
+    kwargs.setdefault('--rootdir', rootdir)
+    args += tuple([f'{k}={v}' for k, v in kwargs.items()])
 
     with chdir(rootdir):
         if with_coverage:
@@ -206,13 +209,13 @@ def test(*args, **kwargs):
                 f'--rcfile={coverage_config}',
                 f'--data-file={coverage_file}',
                 '-m', 'pytest', pkg_dir
-            ] + list(args) + [f'{k}={v}' for k, v in kwargs]
+            ] + list(args)
             with stdout_context():
                 process = subprocess.run(cmd, stdout=sys.stdout, stderr=subprocess.STDOUT)
             rc = process.returncode
         else:
             with stdout_context():
-                rc = pytest.main([pkg_dir] + list(args), **kwargs)
+                rc = pytest.main([pkg_dir] + list(args))
 
     if rc and raise_exception:
         raise TestError('Failed')


### PR DESCRIPTION
## Description

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes https://github.com/sot/skare3/issues/1294

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Tested with pytest == 8.3.4 .  

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] No unit tests

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Hoping for help from @jeanconn or @javierggt.

#### Testing <package>.test()
From this github repo, test the test runner via the `>>> package.test(*args, **kwargs)` path.
```
masters) ➜  testr git:(set-rootdir) ipython
Python 3.11.8 | packaged by conda-forge | (main, Feb 16 2024, 20:49:36) [Clang 16.0.6 ]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.29.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import ska_helpers

In [2]: ska_helpers.test(**{"-k": "utils"})
================================================================== test session starts ==================================================================
platform darwin -- Python 3.11.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/aldcroft/miniconda3-arm/envs/masters/lib/python3.11/site-packages
plugins: timeout-2.2.0, anyio-4.3.0
collected 57 items / 27 deselected / 30 selected

ska_helpers/tests/test_utils.py ..............................                                                                                    [100%]

=========================================================== 30 passed, 27 deselected in 0.83s ===========================================================
Out[2]: False

In [3]: ska_helpers.test("-k", "utils")
================================================================== test session starts ==================================================================
platform darwin -- Python 3.11.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/aldcroft/miniconda3-arm/envs/masters/lib/python3.11/site-packages
plugins: timeout-2.2.0, anyio-4.3.0
collected 57 items / 27 deselected / 30 selected

ska_helpers/tests/test_utils.py ..............................                                                                                    [100%]

=========================================================== 30 passed, 27 deselected in 0.43s ===========================================================
Out[3]: False

In [4]: ska_helpers.test("-k=utils")
================================================================== test session starts ==================================================================
platform darwin -- Python 3.11.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/aldcroft/miniconda3-arm/envs/masters/lib/python3.11/site-packages
plugins: timeout-2.2.0, anyio-4.3.0
collected 57 items / 27 deselected / 30 selected

ska_helpers/tests/test_utils.py ..............................                                                                                    [100%]

=========================================================== 30 passed, 27 deselected in 0.41s ===========================================================
Out[4]: False
```
I also put in a temporary statement to print the `args` that get passed to the `pytest` call and confirmed the expected `--rootdir`.
```
In [3]: ska_helpers.test("-k", "utils")
('-k', 'utils', '-p', 'no:cacheprovider', '-p', 'no:hypothesispytest', '-p', 'no:hypothesis', '--rootdir=/Users/aldcroft/miniconda3-arm/envs/masters/lib/python3.11/site-packages')
```

For other functional testing, @jeanconn ran tests for a single package from ska_testr and confirmed success with pytest 8.3.4


```
(perl-play) jeanconn-fido> cd ~/git/ska_testr
(perl-play) jeanconn-fido> export PYTHONPATH=/home/jeanconn/git/testr
(perl-play) jeanconn-fido> python -c "import testr; print(testr.__version__)"
4.12.1.dev3+g9e6bb45
(perl-play) jeanconn-fido> python -c "import pytest; print(pytest.__version__)"
8.3.4
(perl-play) jeanconn-fido> run_testr --include Quaternion
...
****************************************
*** package Quaternion               ***
****************************************

Copying input tests /proj/sot/ska/jeanproj/git/ska_testr/packages/Quaternion to output dir /proj/sot/ska/jeanproj/git/ska_testr/outputs/logs/Linux_2024-12-29T15-32-22_2af167b_fido.cfa.harvard.edu/Quaternion
Running python test_unit.py script
============================= test session starts ==============================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0 -- /fido.real/miniforge3/envs/perl-play/bin/python
rootdir: /fido.real/miniforge3/envs/perl-play/lib/python3.12/site-packages
configfile: ../../../../../../../proj/sot/ska/jeanproj/git/ska_testr/pytest.ini
plugins: timeout-2.3.1, anyio-4.7.0, typeguard-4.3.0
collecting ... collected 72 items

Quaternion/tests/test_all.py::test_shape PASSED
Quaternion/tests/test_all.py::test_init_exceptions PASSED
Quaternion/tests/test_all.py::test_from_q PASSED
Quaternion/tests/test_all.py::test_from_eq PASSED
Quaternion/tests/test_all.py::test_from_eq_vectorized PASSED
Quaternion/tests/test_all.py::test_from_eq_shapes PASSED
Quaternion/tests/test_all.py::test_transform_from_eq PASSED
Quaternion/tests/test_all.py::test_from_transform PASSED
Quaternion/tests/test_all.py::test_from_transform_vectorized PASSED
Quaternion/tests/test_all.py::test_eq_from_transform PASSED
Quaternion/tests/test_all.py::test_from_q_vectorized PASSED
Quaternion/tests/test_all.py::test_inv_eq PASSED
Quaternion/tests/test_all.py::test_inv_q PASSED
Quaternion/tests/test_all.py::test_inv_vectorized PASSED
Quaternion/tests/test_all.py::test_dq PASSED
Quaternion/tests/test_all.py::test_dq_vectorized PASSED
Quaternion/tests/test_all.py::test_vector_to_scalar_correspondence PASSED
Quaternion/tests/test_all.py::test_ra0_roll0 PASSED
Quaternion/tests/test_all.py::test_repr PASSED
Quaternion/tests/test_all.py::test_numeric_underflow PASSED
Quaternion/tests/test_all.py::test_div_mult PASSED
Quaternion/tests/test_all.py::test_mult_vectorized PASSED
Quaternion/tests/test_all.py::test_normalize PASSED
Quaternion/tests/test_all.py::test_copy PASSED
Quaternion/tests/test_all.py::test_format ra=10.00000, dec=20.00000, roll=30.00000
PASSED
Quaternion/tests/test_all.py::test_scalar_attribute_types PASSED
Quaternion/tests/test_all.py::test_mult_and_dq_broadcasted PASSED
Quaternion/tests/test_all.py::test_array_attribute_types PASSED
Quaternion/tests/test_all.py::test_pickle PASSED
Quaternion/tests/test_all.py::test_init_quat_from_attitude PASSED
Quaternion/tests/test_all.py::test_rotate_x_to_vec_regress PASSED
Quaternion/tests/test_all.py::test_rotate_x_to_vec_functional[keep_z] PASSED
Quaternion/tests/test_all.py::test_rotate_x_to_vec_functional[shortest] PASSED
Quaternion/tests/test_all.py::test_rotate_x_to_vec_functional[radec] PASSED
Quaternion/tests/test_all.py::test_rotate_x_to_vec_bad_method PASSED
Quaternion/tests/test_all.py::test_rotate_about_vec PASSED
Quaternion/tests/test_all.py::test_rotate_about_vec_exceptions PASSED
Quaternion/tests/test_all.py::test_setting_different_shape[q] PASSED
Quaternion/tests/test_all.py::test_setting_different_shape[equatorial] PASSED
Quaternion/tests/test_all.py::test_setting_different_shape[transform] PASSED
Quaternion/tests/test_all.py::test_quat_to_equatorial PASSED
Quaternion/tests/test_all.py::test_quat_mult PASSED
Quaternion/tests/test_all.py::test_quat_descriptor_not_required_no_default PASSED
Quaternion/tests/test_all.py::test_quat_descriptor_is_required PASSED
Quaternion/tests/test_all.py::test_quat_descriptor_has_default PASSED
Quaternion/tests/test_all.py::test_quat_descriptor_is_required_has_default_exception PASSED
Quaternion/tests/test_shaped.py::test_getitem[q] PASSED
Quaternion/tests/test_shaped.py::test_getitem[equatorial] PASSED
Quaternion/tests/test_shaped.py::test_getitem[transform] PASSED
Quaternion/tests/test_shaped.py::test_shape_changing_methods[copy] PASSED
Quaternion/tests/test_shaped.py::test_shape_changing_methods[reshape] PASSED
Quaternion/tests/test_shaped.py::test_shape_changing_methods[transpose] PASSED
Quaternion/tests/test_shaped.py::test_shape_changing_methods[flatten] PASSED
Quaternion/tests/test_shaped.py::test_shape_changing_methods[ravel] PASSED
Quaternion/tests/test_shaped.py::test_shape_changing_methods[swapaxes] PASSED
Quaternion/tests/test_shaped.py::test_shape_changing_methods[diagonal] PASSED
Quaternion/tests/test_shaped.py::test_shape_changing_methods[squeeze] PASSED
Quaternion/tests/test_shaped.py::test_shape_changing_methods[take] PASSED
Quaternion/tests/test_shaped.py::test_shape_changing_T_property PASSED
Quaternion/tests/test_shaped.py::test_applicable_methods[moveaxis-args0] PASSED
Quaternion/tests/test_shaped.py::test_applicable_methods[rollaxis-args1] PASSED
Quaternion/tests/test_shaped.py::test_applicable_methods[atleast_1d-args2] PASSED
Quaternion/tests/test_shaped.py::test_applicable_methods[atleast_2d-args3] PASSED
Quaternion/tests/test_shaped.py::test_applicable_methods[atleast_3d-args4] PASSED
Quaternion/tests/test_shaped.py::test_applicable_methods[expand_dims-args5] PASSED
Quaternion/tests/test_shaped.py::test_applicable_methods[broadcast_to-args6] PASSED
Quaternion/tests/test_shaped.py::test_applicable_methods[flip-args7] PASSED
Quaternion/tests/test_shaped.py::test_applicable_methods[fliplr-args8] PASSED
Quaternion/tests/test_shaped.py::test_applicable_methods[flipud-args9] PASSED
Quaternion/tests/test_shaped.py::test_applicable_methods[rot90-args10] PASSED
Quaternion/tests/test_shaped.py::test_applicable_methods[roll-args11] PASSED
Quaternion/tests/test_shaped.py::test_applicable_methods[delete-args12] PASSED

- generated xml file: /proj/sot/ska/jeanproj/git/ska_testr/outputs/logs/Linux_2024-12-29T15-32-22_2af167b_fido.cfa.harvard.edu/Quaternion/test_unit.py.xml -
============================== 72 passed in 2.70s ==============================
Running python post_check_logs.py script
****************************************
*** Quaternion Test Summary          ***
*** test_unit.py         pass        ***
*** post_check_logs.py   pass        ***
****************************************
```
The rootdir looks appropriate to my installation, though it is a bit amusing that the pytest.ini is now relative.

For reference, this was the top matter with testr master
```
============================= test session starts ==============================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0 -- /fido.real/miniforge3/envs/perl-play/bin/python
rootdir: /proj/sot/ska/jeanproj/git/ska_testr
configfile: pytest.ini
plugins: timeout-2.3.1, anyio-4.7.0, typeguard-4.3.0
collecting ... collected 72 items

../../../../../../../proj/sot/ska/jeanproj/git/ska_testr/tests/test_all.py::test_shape PASSED
```